### PR TITLE
PoC: adds stdio-to-sse proxy

### DIFF
--- a/src/mcp/proxy/Makefile
+++ b/src/mcp/proxy/Makefile
@@ -1,0 +1,16 @@
+.PHONY: build test clean integration-test debug-connection
+
+build:
+	go build -o stdiosseproxy .
+
+test:
+	go test -v ./proxy
+
+integration-test:
+	RUN_INTEGRATION_TESTS=1 go test -v ./integration
+
+debug-connection:
+	go run integration/cmd/debug_connection.go
+
+clean:
+	rm -f stdiosseproxy

--- a/src/mcp/proxy/cmd/debug_client.go
+++ b/src/mcp/proxy/cmd/debug_client.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// InitializeRequest represents the MCP initialization message
+// using the correct format for 2024-11-05
+type InitializeRequest struct {
+	JSONRPC string `json:"jsonrpc"`
+	ID      string `json:"id"`
+	Method  string `json:"method"`
+	Params  struct {
+		ProtocolVersion string `json:"protocolVersion"`
+		ClientInfo      struct {
+			Name    string `json:"name"`
+			Version string `json:"version"`
+		} `json:"clientInfo"`
+		Capabilities struct{} `json:"capabilities"`
+	} `json:"params"`
+}
+
+func main() {
+	// Default URL
+	serverURL := "http://localhost:8000/sse"
+	if len(os.Args) > 1 {
+		serverURL = os.Args[1]
+	}
+
+	fmt.Printf("Testing MCP connection to: %s\n", serverURL)
+
+	// Step 1: Create the SSE connection
+	client := &http.Client{Timeout: 0}
+	req, err := http.NewRequest("GET", serverURL, nil)
+	if err != nil {
+		log.Fatalf("Error creating request: %v", err)
+	}
+
+	// Set standard SSE headers
+	req.Header.Set("Accept", "text/event-stream")
+	req.Header.Set("Cache-Control", "no-cache")
+	req.Header.Set("Connection", "keep-alive")
+
+	// Make the request
+	fmt.Println("Connecting to SSE endpoint...")
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatalf("Error connecting: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Verify connection
+	fmt.Printf("Connected, status: %s\n", resp.Status)
+
+	// Process SSE events in background
+	go func() {
+		scanner := bufio.NewScanner(resp.Body)
+		var eventType, data string
+		inEvent := false
+
+		for scanner.Scan() {
+			line := scanner.Text()
+			fmt.Printf("RAW: %s\n", line)
+
+			// Empty line marks the end of an event
+			if line == "" {
+				if inEvent {
+					fmt.Printf("EVENT: type=%s data=%s\n", eventType, data)
+					if eventType == "endpoint" {
+						// We received the POST URL
+						postURL := data
+						if strings.HasPrefix(postURL, "/") {
+							// It's a relative URL, extract the base
+							parts := strings.Split(serverURL, "/")
+							baseURL := parts[0] + "//" + parts[2]
+							postURL = baseURL + postURL
+						}
+						fmt.Printf("POST URL: %s\n", postURL)
+
+						// Now send an initialize request to the POST URL
+						sendInitializeRequest(postURL)
+					}
+					eventType = ""
+					data = ""
+					inEvent = false
+				}
+				continue
+			}
+
+			// Check for event type or data
+			if strings.HasPrefix(line, "event:") {
+				eventType = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+				inEvent = true
+			} else if strings.HasPrefix(line, "data:") {
+				inEvent = true
+				if data != "" {
+					data += "\n"
+				}
+				data += strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+			}
+		}
+
+		if err := scanner.Err(); err != nil {
+			fmt.Printf("Error reading SSE: %v\n", err)
+		}
+	}()
+
+	// Wait for user to exit
+	fmt.Println("Press Enter to exit")
+	bufio.NewReader(os.Stdin).ReadBytes('\n')
+	fmt.Println("Exiting")
+}
+
+func sendInitializeRequest(postURL string) {
+	// Create a properly formatted initialization request
+	req := InitializeRequest{
+		JSONRPC: "2.0",
+		ID:      "1",
+		Method:  "initialize",
+	}
+	req.Params.ProtocolVersion = "mcp/2024-11-05"
+	req.Params.ClientInfo.Name = "debug-client"
+	req.Params.ClientInfo.Version = "1.0.0"
+
+	// Marshal to JSON
+	data, err := json.Marshal(req)
+	if err != nil {
+		fmt.Printf("Error marshaling request: %v\n", err)
+		return
+	}
+
+	fmt.Printf("Sending initialize request: %s\n", string(data))
+
+	// Send the request
+	httpClient := &http.Client{Timeout: 10 * time.Second}
+	resp, err := httpClient.Post(postURL, "application/json", bytes.NewBuffer(data))
+	if err != nil {
+		fmt.Printf("Error sending request: %v\n", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	// Read the response
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(resp.Body)
+	response := buf.String()
+
+	fmt.Printf("Response status: %s\n", resp.Status)
+	fmt.Printf("Response body: %s\n", response)
+}

--- a/src/mcp/proxy/go.mod
+++ b/src/mcp/proxy/go.mod
@@ -1,0 +1,3 @@
+module github.com/featureform/stdiosseproxy
+
+go 1.23

--- a/src/mcp/proxy/integration/cmd/debug_connection.go
+++ b/src/mcp/proxy/integration/cmd/debug_connection.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// This is a standalone utility to debug connections to the MCP server
+// You can run it directly with: go run integration/debug_connection.go
+
+func main() {
+	// Default URL if not provided
+	serverURL := "http://localhost:8000/sse"
+	if len(os.Args) > 1 {
+		serverURL = os.Args[1]
+	}
+
+	fmt.Printf("Connecting to SSE endpoint: %s\n", serverURL)
+
+	// Configure an HTTP client
+	client := &http.Client{
+		Timeout: 0, // No timeout for SSE connections
+	}
+
+	// Configure an HTTP request for SSE
+	req, err := http.NewRequest("GET", serverURL, nil)
+	if err != nil {
+		log.Fatalf("Error creating SSE request: %v", err)
+	}
+
+	// Set headers for SSE
+	req.Header.Set("Accept", "text/event-stream")
+	req.Header.Set("Cache-Control", "no-cache")
+	req.Header.Set("Connection", "keep-alive")
+
+	// Make the request
+	fmt.Println("Sending request...")
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Fatalf("Error connecting to SSE endpoint: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Check response status
+	fmt.Printf("Connected, status: %s\n", resp.Status)
+	for name, values := range resp.Header {
+		fmt.Printf("Header: %s = %s\n", name, strings.Join(values, ", "))
+	}
+
+	// Set a timeout for reading from the SSE stream
+	totalTimeout := 30 * time.Second
+	// deadline := time.Now().Add(totalTimeout)
+
+	fmt.Printf("Waiting for events (timeout: %v)...\n", totalTimeout)
+
+	// Read the first bytes from the response to verify connection
+	buffer := make([]byte, 1024)
+	readTimeout := time.After(totalTimeout)
+
+	// Create a channel to receive the read result
+	readChan := make(chan struct {
+		n   int
+		err error
+	})
+
+	// Read in a goroutine to handle timeouts
+	go func() {
+		n, err := resp.Body.Read(buffer)
+		readChan <- struct {
+			n   int
+			err error
+		}{n, err}
+	}()
+
+	// Wait for either a read result or a timeout
+	select {
+	case result := <-readChan:
+		if result.err != nil && result.err != io.EOF {
+			fmt.Printf("Error reading from SSE stream: %v\n", result.err)
+		} else if result.n > 0 {
+			fmt.Printf("Received %d bytes:\n%s\n", result.n, string(buffer[:result.n]))
+		} else {
+			fmt.Println("No data received before connection closed")
+		}
+	case <-readTimeout:
+		fmt.Println("Timeout waiting for data")
+	}
+
+	fmt.Println("Check complete")
+}

--- a/src/mcp/proxy/integration/integration_test.go
+++ b/src/mcp/proxy/integration/integration_test.go
@@ -1,0 +1,265 @@
+package integration
+
+import (
+	"bytes"
+	"encoding/json"
+	"log"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/featureform/stdiosseproxy/proxy"
+)
+
+// InitializeRequest represents the MCP initialization message
+// according to the 2024-11-05 specification
+type InitializeRequest struct {
+	JSONRPC string `json:"jsonrpc"`
+	ID      string `json:"id"`
+	Method  string `json:"method"`
+	Params  struct {
+		ProtocolVersion string `json:"protocolVersion"`
+		ClientInfo      struct {
+			Name    string `json:"name"`
+			Version string `json:"version"`
+		} `json:"clientInfo"`
+		Capabilities struct{} `json:"capabilities"`
+	} `json:"params"`
+}
+
+// createInitializeRequest creates a properly formatted initialization message
+func createInitializeRequest() InitializeRequest {
+	req := InitializeRequest{
+		JSONRPC: "2.0",
+		ID:      "1",
+		Method:  "initialize",
+	}
+	req.Params.ProtocolVersion = "mcp/2024-11-05"
+	req.Params.ClientInfo.Name = "stdiosseproxy-test"
+	req.Params.ClientInfo.Version = "1.0.0"
+
+	return req
+}
+
+// TestInitializationFlow tests the initialization flow with a real MCP server
+func TestInitializationFlow(t *testing.T) {
+	// Skip this test if the integration flag is not provided
+	if os.Getenv("RUN_INTEGRATION_TESTS") != "1" {
+		t.Skip("Skipping integration test. Set RUN_INTEGRATION_TESTS=1 to run.")
+	}
+
+	// URL of the actual MCP server - fix the URL format
+	serverURL := "http://localhost:8000/sse"
+
+	// Create a buffer for the input (to the server)
+	initReq := createInitializeRequest()
+	initReqBytes, err := json.Marshal(initReq)
+	if err != nil {
+		t.Fatalf("Failed to marshal initialize request: %v", err)
+	}
+
+	inputBuffer := bytes.NewBufferString(string(initReqBytes) + "\n")
+
+	// Create a buffer for the output (from the server)
+	outputBuffer := &bytes.Buffer{}
+
+	// Create a logger that prints to stdout for easier debugging
+	testLogger := log.New(os.Stdout, "INTEGRATION-TEST: ", log.Ltime)
+
+	// Create the proxy server
+	proxyServer := proxy.NewProxyServer(serverURL, testLogger)
+	proxyServer.InputReader = inputBuffer
+	proxyServer.OutputWriter = outputBuffer
+
+	// Start the proxy in a goroutine
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- proxyServer.Start()
+	}()
+
+	// Wait for a reasonable amount of time for the initialization flow
+	// to complete or fail - increased timeout
+	var proxyError error
+	select {
+	case proxyError = <-errChan:
+		// If we get an error, log it but continue testing
+		t.Logf("Proxy returned error: %v", proxyError)
+	case <-time.After(10 * time.Second):
+		// If we timeout, that's okay - the proxy is still running
+		t.Log("Proxy is still running after 10 seconds")
+	}
+
+	// Stop the proxy
+	proxyServer.Stop()
+
+	// Debug log current state
+	t.Logf("After test - Connected: %v, PostURL: %s",
+		proxyServer.Connected, proxyServer.PostURL)
+
+	// Verify the proxy has received the POST endpoint
+	if proxyServer.PostURL == "" {
+		t.Error("Proxy did not receive a POST endpoint URL")
+	} else {
+		t.Logf("POST endpoint URL: %s", proxyServer.PostURL)
+	}
+
+	// Check the output buffer for a valid response
+	output := outputBuffer.String()
+	t.Logf("Server response: %s", output)
+
+	// Verify we got a response that looks like a valid JSON-RPC response
+	if !strings.Contains(output, "\"jsonrpc\":\"2.0\"") ||
+		!strings.Contains(output, "\"id\":\"1\"") {
+		t.Error("Did not receive valid JSON-RPC response")
+	}
+
+	// Verify that the response is related to initialization
+	// This depends on the exact server implementation, but we can at least
+	// check for common fields we'd expect in the response
+	if !strings.Contains(output, "\"result\"") {
+		t.Error("Response does not contain a result field")
+	}
+
+	// Try to parse the response to verify it's valid JSON
+	var responseMap map[string]interface{}
+	if err := json.NewDecoder(strings.NewReader(output)).Decode(&responseMap); err != nil {
+		t.Errorf("Failed to parse server response as JSON: %v", err)
+	} else {
+		// If we can parse it, log the response structure
+		t.Logf("Response structure: %+v", responseMap)
+
+		// Check if there's a server field in the result
+		if result, ok := responseMap["result"].(map[string]interface{}); ok {
+			if server, ok := result["server"].(map[string]interface{}); ok {
+				t.Logf("Server name: %v, version: %v",
+					server["name"], server["version"])
+			}
+		}
+	}
+}
+
+// TestRealMessageExchange tests sending an actual message to the server
+// after initialization
+func TestRealMessageExchange(t *testing.T) {
+	// Skip this test if the integration flag is not provided
+	if os.Getenv("RUN_INTEGRATION_TESTS") != "1" {
+		t.Skip("Skipping integration test. Set RUN_INTEGRATION_TESTS=1 to run.")
+	}
+
+	// URL of the actual MCP server
+	serverURL := "http://localhost:8000/sse"
+
+	// First, we need to initialize
+	initReq := createInitializeRequest()
+	initReqBytes, err := json.Marshal(initReq)
+	if err != nil {
+		t.Fatalf("Failed to marshal initialize request: %v", err)
+	}
+
+	// Create a request for a second message
+	echoRequest := map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      "2",
+		"method":  "echo",
+		"params": map[string]interface{}{
+			"message": "Hello, MCP!",
+		},
+	}
+	echoReqBytes, err := json.Marshal(echoRequest)
+	if err != nil {
+		t.Fatalf("Failed to marshal echo request: %v", err)
+	}
+
+	// Create an initialized notification
+	initializedNotification := map[string]interface{}{
+		"jsonrpc": "2.0",
+		"method":  "initialized",
+		"params":  struct{}{},
+	}
+	initializedBytes, err := json.Marshal(initializedNotification)
+	if err != nil {
+		t.Fatalf("Failed to marshal initialized notification: %v", err)
+	}
+
+	// Prepare the input with multiple messages
+	inputStr := string(initReqBytes) + "\n" +
+		string(initializedBytes) + "\n" +
+		string(echoReqBytes) + "\n"
+
+	inputBuffer := bytes.NewBufferString(inputStr)
+
+	// Create a buffer for the output
+	outputBuffer := &bytes.Buffer{}
+
+	// Create a logger that prints to stdout for easier debugging
+	testLogger := log.New(os.Stdout, "INTEGRATION-TEST: ", log.Ltime)
+
+	// Create the proxy server with a longer timeout
+	proxyServer := proxy.NewProxyServer(serverURL, testLogger)
+	proxyServer.InputReader = inputBuffer
+	proxyServer.OutputWriter = outputBuffer
+
+	// Start the proxy in a goroutine
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- proxyServer.Start()
+	}()
+
+	// Wait for a reasonable amount of time for the message exchange
+	// to complete or fail
+	var proxyError error
+	select {
+	case proxyError = <-errChan:
+		// If we get an error, log it but continue testing
+		t.Logf("Proxy returned error: %v", proxyError)
+	case <-time.After(15 * time.Second):
+		// If we timeout, that's okay - the proxy is still running
+		t.Log("Proxy is still running after 15 seconds")
+	}
+
+	// Stop the proxy
+	proxyServer.Stop()
+
+	// Debug log current state
+	t.Logf("After test - Connected: %v, PostURL: %s",
+		proxyServer.Connected, proxyServer.PostURL)
+
+	// Analyze the output
+	output := outputBuffer.String()
+
+	// Split the output by newlines to get individual responses
+	responses := strings.Split(strings.TrimSpace(output), "\n")
+	t.Logf("Received %d responses", len(responses))
+
+	for i, resp := range responses {
+		t.Logf("Response %d: %s", i+1, resp)
+
+		// Try to parse each response
+		var respMap map[string]interface{}
+		if err := json.Unmarshal([]byte(resp), &respMap); err != nil {
+			t.Errorf("Failed to parse response as JSON: %v", err)
+			continue
+		}
+
+		// Check if it has an ID and matches our requests
+		if id, ok := respMap["id"].(string); ok {
+			switch id {
+			case "1":
+				t.Log("Found response to initialize request")
+			case "2":
+				t.Log("Found response to echo request")
+				// Check the echo response
+				if result, ok := respMap["result"].(map[string]interface{}); ok {
+					if message, ok := result["message"].(string); ok {
+						if message != "Hello, MCP!" {
+							t.Errorf("Echo message mismatch. Expected: 'Hello, MCP!', got: '%s'", message)
+						}
+					} else {
+						t.Error("Echo response doesn't contain expected message field")
+					}
+				}
+			}
+		}
+	}
+}

--- a/src/mcp/proxy/main.go
+++ b/src/mcp/proxy/main.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/featureform/stdiosseproxy/proxy"
+)
+
+func main() {
+	// Check if the URL and optional log file are provided as arguments
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "Usage: stdiosseproxy <server-url> [log-file]")
+		os.Exit(1)
+	}
+
+	serverURL := os.Args[1]
+
+	// Set up logging
+	var logger *log.Logger
+	if len(os.Args) > 2 {
+		logFilePath := os.Args[2]
+		logFile, err := os.OpenFile(logFilePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error opening log file: %v\n", err)
+			os.Exit(1)
+		}
+		defer logFile.Close()
+		logger = log.New(logFile, "SSE-PROXY: ", log.Ldate|log.Ltime|log.Lshortfile)
+	} else {
+		// By default, logs go to stderr
+		logger = log.New(os.Stderr, "SSE-PROXY: ", log.Ldate|log.Ltime|log.Lshortfile)
+	}
+
+	logger.Println("Starting SSE proxy to server:", serverURL)
+	logger.Println("Using MCP protocol version: 2024-11-05")
+
+	// Create the proxy server
+	proxyServer := proxy.NewProxyServer(serverURL, logger)
+
+	// Create a channel to signal shutdown
+	shutdown := make(chan os.Signal, 1)
+	signal.Notify(shutdown, os.Interrupt, syscall.SIGTERM)
+
+	// Start the proxy in a goroutine
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- proxyServer.Start()
+	}()
+
+	// Wait for shutdown signal or error
+	select {
+	case <-shutdown:
+		logger.Println("Received shutdown signal, closing connections...")
+		proxyServer.Stop()
+	case err := <-errChan:
+		logger.Printf("Proxy terminated with error: %v", err)
+	}
+}

--- a/src/mcp/proxy/proxy/proxy.go
+++ b/src/mcp/proxy/proxy/proxy.go
@@ -1,0 +1,350 @@
+package proxy
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ProxyServer represents an SSE proxy server
+type ProxyServer struct {
+	ServerURL    string      // The base URL for the SSE endpoint
+	PostURL      string      // URL for the POST endpoint (received from server)
+	Logger       *log.Logger
+	HTTPClient   *http.Client
+	InputReader  io.Reader
+	OutputWriter io.Writer
+	DoneChan     chan struct{}
+	ErrorChan    chan error
+	WaitGroup    sync.WaitGroup
+	Connected    bool           // Flag to track if we've established the connection
+	Mutex        sync.Mutex     // Mutex to protect concurrent access to state
+	// Add a connection notification channel
+	ConnectedChan chan struct{} // Channel to signal when connection is established
+}
+
+// NewProxyServer creates a new SSE proxy server
+func NewProxyServer(serverURL string, logger *log.Logger) *ProxyServer {
+	if logger == nil {
+		logger = log.New(os.Stderr, "SSE-PROXY: ", log.Ldate|log.Ltime|log.Lshortfile)
+	}
+
+	return &ProxyServer{
+		ServerURL:    serverURL,
+		PostURL:      "",  // This will be populated from the endpoint event
+		Logger:       logger,
+		InputReader:  os.Stdin,
+		OutputWriter: os.Stdout,
+		DoneChan:     make(chan struct{}),
+		ErrorChan:    make(chan error, 1),
+		HTTPClient: &http.Client{
+			Timeout: 0, // No timeout, let the connection persist
+			Transport: &http.Transport{
+				IdleConnTimeout:     90 * time.Second,
+				MaxIdleConns:        100,
+				MaxIdleConnsPerHost: 100,
+			},
+		},
+		Connected:     false,
+		ConnectedChan: make(chan struct{}),
+	}
+}
+
+// Start begins the proxy operation
+func (p *ProxyServer) Start() error {
+	inputChan := make(chan string)
+
+	// Start a goroutine to read from input
+	p.WaitGroup.Add(1)
+	go func() {
+		defer p.WaitGroup.Done()
+		defer close(inputChan)
+
+		scanner := bufio.NewScanner(p.InputReader)
+		for scanner.Scan() {
+			select {
+			case <-p.DoneChan:
+				return
+			default:
+				line := scanner.Text()
+				p.Logger.Printf("Read from stdin: %s", line)
+				inputChan <- line
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			p.Logger.Printf("Error reading from input: %v", err)
+			p.ErrorChan <- fmt.Errorf("input read error: %w", err)
+		}
+	}()
+
+	// Start the SSE connection handler
+	p.WaitGroup.Add(1)
+	go p.handleSSEConnection()
+
+	// Start the HTTP message sender
+	p.WaitGroup.Add(1)
+	go p.handleMessageSending(inputChan)
+
+	// Return first error encountered
+	return <-p.ErrorChan
+}
+
+// Stop gracefully stops the proxy
+func (p *ProxyServer) Stop() {
+	close(p.DoneChan)
+	p.WaitGroup.Wait()
+	p.Logger.Println("Proxy terminated")
+}
+
+// handleSSEConnection establishes and maintains the SSE connection
+func (p *ProxyServer) handleSSEConnection() {
+	defer p.WaitGroup.Done()
+
+	// Configure an HTTP request for SSE
+	req, err := http.NewRequest("GET", p.ServerURL, nil)
+	if err != nil {
+		p.ErrorChan <- fmt.Errorf("error creating SSE request: %w", err)
+		return
+	}
+
+	// Set headers for SSE
+	req.Header.Set("Accept", "text/event-stream")
+	req.Header.Set("Cache-Control", "no-cache")
+	req.Header.Set("Connection", "keep-alive")
+
+	// Make the request
+	p.Logger.Println("Establishing SSE connection to server:", p.ServerURL)
+	resp, err := p.HTTPClient.Do(req)
+	if err != nil {
+		p.ErrorChan <- fmt.Errorf("error connecting to SSE endpoint: %w", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	// Check response status
+	if resp.StatusCode != http.StatusOK {
+		p.ErrorChan <- fmt.Errorf("server returned error status for SSE connection: %s", resp.Status)
+		return
+	}
+
+	p.Logger.Printf("Connected to SSE endpoint, status: %s", resp.Status)
+
+	// Process the SSE stream
+	scanner := bufio.NewScanner(resp.Body)
+	var eventType, data string
+	inEvent := false
+
+	for scanner.Scan() {
+		select {
+		case <-p.DoneChan:
+			return
+		default:
+			line := scanner.Text()
+			p.Logger.Printf("Received SSE line: %s", line)
+			
+			// Empty line marks the end of an event
+			if line == "" {
+				if inEvent {
+					p.processEvent(eventType, data)
+					eventType = ""
+					data = ""
+					inEvent = false
+				}
+				continue
+			}
+
+			// Check for event type or data
+			if strings.HasPrefix(line, "event:") {
+				eventType = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+				inEvent = true
+				p.Logger.Printf("Parsed event type: %s", eventType)
+			} else if strings.HasPrefix(line, "data:") {
+				inEvent = true
+				if data != "" {
+					data += "\n"
+				}
+				data += strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+				p.Logger.Printf("Parsed data: %s", data)
+			}
+		}
+	}
+
+	// Check if we exited the loop due to an error
+	if err := scanner.Err(); err != nil {
+		p.ErrorChan <- fmt.Errorf("error reading SSE stream: %w", err)
+		return
+	}
+
+	// If we get here, the server closed the connection normally
+	p.Logger.Println("Server closed the SSE connection")
+	p.ErrorChan <- fmt.Errorf("server closed the SSE connection")
+}
+
+// processEvent handles different SSE event types
+func (p *ProxyServer) processEvent(eventType, data string) {
+	p.Logger.Printf("Processing SSE event: %s, data: %s", eventType, data)
+
+	switch eventType {
+	case "endpoint":
+		// Store the POST endpoint URL
+		// Handle relative URLs by prepending the base URL
+		postURL := data
+		if strings.HasPrefix(postURL, "/") {
+			// Extract the base URL from the server URL
+			baseURL, err := extractBaseURL(p.ServerURL)
+			if err != nil {
+				p.Logger.Printf("Error extracting base URL: %v", err)
+			} else {
+				postURL = baseURL + postURL
+				p.Logger.Printf("Converted relative URL to absolute: %s", postURL)
+			}
+		}
+
+		p.Mutex.Lock()
+		p.PostURL = postURL
+		p.Connected = true
+		p.Mutex.Unlock()
+		p.Logger.Printf("Received POST endpoint: %s", postURL)
+		
+		// Signal that we're connected
+		select {
+		case p.ConnectedChan <- struct{}{}:
+			p.Logger.Printf("Signaled connection established")
+		default:
+			p.Logger.Printf("Channel already signaled or closed")
+		}
+		
+	case "message":
+		// Write the message data to stdout
+		p.Logger.Printf("Received message: %s", data)
+		// Print a hex/byte dump of the message to help debug
+		p.Logger.Printf("Raw message bytes: %x", []byte(data))
+		fmt.Fprintln(p.OutputWriter, data)
+		
+	default:
+		p.Logger.Printf("Unknown event type: %s", eventType)
+	}
+}
+
+// handleMessageSending sends messages from stdin to the HTTP endpoint
+func (p *ProxyServer) handleMessageSending(inputChan <-chan string) {
+	defer p.WaitGroup.Done()
+
+	for {
+		select {
+		case <-p.DoneChan:
+			return
+		case input, ok := <-inputChan:
+			if !ok {
+				p.Logger.Println("Input channel closed, stopping sender")
+				return
+			}
+
+			// Wait for endpoint URL with a timeout
+			connected := p.waitForConnection(30 * time.Second)
+			if !connected {
+				p.Logger.Println("Timed out waiting for POST endpoint URL, proceeding anyway...")
+			}
+
+			// Send the message
+			if err := p.sendMessage(input); err != nil {
+				p.Logger.Printf("Error sending message: %v", err)
+				// Don't exit on send errors, just log them
+			}
+		}
+	}
+}
+
+// waitForConnection waits for the connection to be established with a timeout
+func (p *ProxyServer) waitForConnection(timeout time.Duration) bool {
+	if p.isConnected() {
+		return true
+	}
+
+	p.Logger.Printf("Waiting for POST endpoint URL (timeout: %v)...", timeout)
+	
+	select {
+	case <-p.ConnectedChan:
+		p.Logger.Println("Connection established signal received")
+		return true
+	case <-time.After(timeout):
+		p.Logger.Println("Timed out waiting for connection")
+		return false
+	case <-p.DoneChan:
+		p.Logger.Println("Done signal received while waiting for connection")
+		return false
+	}
+}
+
+// isConnected checks if we have received the POST endpoint URL
+func (p *ProxyServer) isConnected() bool {
+	p.Mutex.Lock()
+	defer p.Mutex.Unlock()
+	result := p.Connected && p.PostURL != ""
+	p.Logger.Printf("Connection check: %v (Connected: %v, PostURL: %s)", 
+		result, p.Connected, p.PostURL)
+	return result
+}
+
+// extractBaseURL extracts the base URL (scheme + host) from a full URL
+func extractBaseURL(fullURL string) (string, error) {
+	parsedURL, err := url.Parse(fullURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse URL: %w", err)
+	}
+
+	// Return scheme + host
+	baseURL := fmt.Sprintf("%s://%s", parsedURL.Scheme, parsedURL.Host)
+	return baseURL, nil
+}
+
+// sendMessage sends a message to the POST endpoint
+func (p *ProxyServer) sendMessage(message string) error {
+	p.Mutex.Lock()
+	postURL := p.PostURL
+	p.Mutex.Unlock()
+
+	if postURL == "" {
+		return fmt.Errorf("no POST endpoint URL available")
+	}
+
+	// Create the request
+	req, err := http.NewRequest("POST", postURL, bytes.NewBufferString(message))
+	if err != nil {
+		return fmt.Errorf("error creating POST request: %w", err)
+	}
+
+	// Set content type for JSON-RPC
+	req.Header.Set("Content-Type", "application/json")
+	
+	// Check for session ID in the URL
+	parsedURL, err := url.Parse(postURL)
+	if err == nil && parsedURL.Query().Get("session_id") != "" {
+		sessionID := parsedURL.Query().Get("session_id")
+		p.Logger.Printf("Found session ID in URL: %s", sessionID)
+	}
+
+	// Send the request
+	p.Logger.Printf("Sending message to POST endpoint: %s", message)
+	resp, err := p.HTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("error sending POST request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Check response status
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("server returned error status for POST: %s", resp.Status)
+	}
+
+	p.Logger.Printf("Message sent successfully, status: %s", resp.Status)
+	return nil
+}

--- a/src/mcp/proxy/proxy/proxy_test.go
+++ b/src/mcp/proxy/proxy/proxy_test.go
@@ -1,0 +1,254 @@
+package proxy
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// mockReadCloser is a simple mock for io.ReadCloser
+type mockReadCloser struct {
+	io.Reader
+}
+
+func (m mockReadCloser) Close() error {
+	return nil
+}
+
+func TestSSEConnectionAndEndpointEvent(t *testing.T) {
+	// Create a mock SSE server
+	sseServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify the request headers
+		if r.Header.Get("Accept") != "text/event-stream" {
+			t.Errorf("Expected Accept header to be text/event-stream, got %s", r.Header.Get("Accept"))
+		}
+
+		// Set SSE headers
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+		w.WriteHeader(http.StatusOK)
+
+		// Send the endpoint event
+		postURL := "http://localhost:12345/post"
+		fmt.Fprintf(w, "event: endpoint\ndata: %s\n\n", postURL)
+
+		// Flush to ensure the message is sent immediately
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+
+		// Keep the connection open for a bit
+		time.Sleep(300 * time.Millisecond)
+
+		// Send a message event
+		fmt.Fprintf(w, "event: message\ndata: {\"jsonrpc\":\"2.0\",\"result\":\"test response\"}\n\n")
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+
+		// Keep the connection open until test completes
+		select {
+		case <-r.Context().Done():
+			return
+		case <-time.After(1 * time.Second):
+			return
+		}
+	}))
+	defer sseServer.Close()
+
+	// Create a mock POST server
+	postReceived := make(chan string, 1)
+	postServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify the request method and headers
+		if r.Method != "POST" {
+			t.Errorf("Expected POST request, got %s", r.Method)
+		}
+
+		// Read the request body
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("Error reading request body: %v", err)
+		}
+
+		// Send the body to our channel for verification
+		postReceived <- string(body)
+
+		// Return a success response
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer postServer.Close()
+
+	// Create buffers for testing stdin/stdout
+	inputBuffer := strings.NewReader("{\"jsonrpc\":\"2.0\",\"method\":\"test\",\"params\":{}}\n")
+	outputBuffer := &bytes.Buffer{}
+	
+	// Create a test logger that writes to a buffer
+	var logBuffer bytes.Buffer
+	testLogger := log.New(&logBuffer, "TEST: ", 0)
+	
+	// Create a proxy server with our test servers
+	proxy := &ProxyServer{
+		ServerURL:    sseServer.URL,
+		Logger:       testLogger,
+		InputReader:  inputBuffer,
+		OutputWriter: outputBuffer,
+		DoneChan:     make(chan struct{}),
+		ErrorChan:    make(chan error, 1),
+		HTTPClient:   http.DefaultClient,
+	}
+	
+	// Start the proxy in a goroutine
+	go func() {
+		proxy.Start()
+	}()
+	
+	// Wait for the POST request to be received or timeout
+	var receivedMessage string
+	select {
+	case receivedMessage = <-postReceived:
+		// Got the message
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timed out waiting for POST request")
+	}
+	
+	// Verify the POST message
+	expectedMessage := "{\"jsonrpc\":\"2.0\",\"method\":\"test\",\"params\":{}}"
+	if receivedMessage != expectedMessage {
+		t.Errorf("Expected POST message %s, got %s", expectedMessage, receivedMessage)
+	}
+	
+	// Wait for the SSE message to be processed
+	time.Sleep(500 * time.Millisecond)
+	
+	// Stop the proxy
+	proxy.Stop()
+	
+	// Verify the output contains the expected message
+	output := outputBuffer.String()
+	expectedOutput := "{\"jsonrpc\":\"2.0\",\"result\":\"test response\"}"
+	if !strings.Contains(output, expectedOutput) {
+		t.Errorf("Expected output to contain %s, got %s", expectedOutput, output)
+	}
+
+	// Verify that the proxy updated its PostURL
+	if !strings.Contains(proxy.PostURL, "localhost:12345/post") {
+		t.Errorf("Expected PostURL to be set to the endpoint value, got %s", proxy.PostURL)
+	}
+}
+
+func TestErrorHandling(t *testing.T) {
+	// Test with a URL that doesn't exist
+	proxy := NewProxyServer("http://localhost:12345", nil)
+	
+	// Use test buffers
+	proxy.InputReader = strings.NewReader("test message\n")
+	proxy.OutputWriter = &bytes.Buffer{}
+	
+	// Start the proxy
+	errorChan := make(chan error, 1)
+	go func() {
+		errorChan <- proxy.Start()
+	}()
+	
+	// Wait for the error
+	var err error
+	select {
+	case err = <-errorChan:
+		// Got an error, as expected
+	case <-time.After(2 * time.Second):
+		t.Fatalf("Timed out waiting for error")
+	}
+	
+	// Verify the error is about connection
+	if err == nil || !strings.Contains(err.Error(), "error connecting to SSE endpoint") {
+		t.Errorf("Expected SSE connection error, got: %v", err)
+	}
+}
+
+func TestServerErrors(t *testing.T) {
+	// Create a mock server that returns a 500 error
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+	
+	// Create a proxy with the test server
+	proxy := NewProxyServer(server.URL, nil)
+	proxy.InputReader = strings.NewReader("test message\n")
+	proxy.OutputWriter = &bytes.Buffer{}
+	
+	// Start the proxy and wait for error
+	errorChan := make(chan error, 1)
+	go func() {
+		errorChan <- proxy.Start()
+	}()
+	
+	// Verify error about server status
+	var err error
+	select {
+	case err = <-errorChan:
+		// Got an error, as expected
+	case <-time.After(2 * time.Second):
+		t.Fatalf("Timed out waiting for error")
+	}
+	
+	if err == nil || !strings.Contains(err.Error(), "server returned error status for SSE connection") {
+		t.Errorf("Expected server error status, got: %v", err)
+	}
+}
+
+func TestMalformedSSEEvents(t *testing.T) {
+	// Create a mock server that returns malformed SSE
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		
+		// Send malformed SSE (missing event type)
+		fmt.Fprintln(w, "data: malformed message")
+		fmt.Fprintln(w, "")
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+	}))
+	defer server.Close()
+	
+	// Create a test logger that writes to a buffer
+	var logBuffer bytes.Buffer
+	testLogger := log.New(&logBuffer, "TEST: ", 0)
+	
+	// Create a proxy with the test server
+	proxy := NewProxyServer(server.URL, testLogger)
+	proxy.InputReader = strings.NewReader("test message\n")
+	outputBuffer := &bytes.Buffer{}
+	proxy.OutputWriter = outputBuffer
+	
+	// Start the proxy
+	go func() {
+		proxy.Start()
+	}()
+	
+	// Give it time to process
+	time.Sleep(500 * time.Millisecond)
+	
+	// Stop the proxy
+	proxy.Stop()
+	
+	// Verify the log contains a message about the unknown event type
+	logOutput := logBuffer.String()
+	if !strings.Contains(logOutput, "Unknown event type") {
+		t.Errorf("Expected log to mention 'Unknown event type', got: %s", logOutput)
+	}
+	
+	// Verify no output for malformed event
+	output := outputBuffer.String()
+	if strings.Contains(output, "malformed message") {
+		t.Errorf("Expected no output for malformed event, got: %s", output)
+	}
+}

--- a/src/mcp/proxy/run_integration_tests.sh
+++ b/src/mcp/proxy/run_integration_tests.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# This script runs the integration tests against a running MCP server
+# The server should be running on http://localhost:8000/sse
+
+# Build the proxy binary if it doesn't exist
+if [ ! -f ./stdiosseproxy ]; then
+    echo "Building stdiosseproxy binary..."
+    go build -o stdiosseproxy .
+fi
+
+# Set the environment variable to enable integration tests
+export RUN_INTEGRATION_TESTS=1
+
+# Run the integration tests with verbose output
+echo "Running integration tests..."
+go test -v ./integration
+
+# Reset the environment variable
+unset RUN_INTEGRATION_TESTS
+
+echo "Integration tests completed."


### PR DESCRIPTION
To test the proxy, simple run the following FastMCP server in a virtual env:

```python
from mcp.server.fastmcp import FastMCP

mcp = FastMCP("Demo")


@mcp.tool()
def add(a: int, b: int) -> int:
    """Add two numbers"""
    return a + b


if __name__ == "__main__":
    mcp.run(transport="sse")
```

When running, you should be able to see the the SSE even endpoint at `http://localhost:8000/sse` in your browser.

Stepping through the integration test should provide a good overview of how the proxy functions.

To run the inspector and test tool listing and usage, in your terminal run:

```shell
npx @modelcontextprotocol/inspector go run main.go http://localhost:8000/sse proxy-logs.txt
```

All you have to do is click "Connect" in the inspector UI.

<img width="1510" alt="Screen Shot 2025-03-31 at 11 16 57 AM" src="https://github.com/user-attachments/assets/a721a27b-dc8f-4cd8-a1f0-9c8b0500e4ca" />

<img width="863" alt="Screen Shot 2025-03-31 at 11 10 38 AM" src="https://github.com/user-attachments/assets/cde5d64b-6f01-481f-b901-8664ff2302d0" />
