### PR TITLE
Return 403 on unauthorized error, add token to context

### DIFF
--- a/src/mcpengine/server/auth/backend.py
+++ b/src/mcpengine/server/auth/backend.py
@@ -201,28 +201,16 @@ class BearerTokenBackend(AuthenticationBackend):
         except Exception as e:
             raise Exception(f"Error preparing public key: {str(e)}")
 
-        # Verify and decode the token
-        try:
-            payload = jwt.decode(
-                token,
-                public_key,
-                algorithms=["RS256"],  # Adjust if your IdP uses a different algorithm
-                options={
-                    "verify_signature": True,
-                    "verify_exp": True,
-                    "verify_aud": False,
-                    "verify_iat": True,
-                    "verify_iss": True,
-                    "require": ["exp", "iat", "iss"],  # , "aud"]  # Required claims
-                },
-                # audience="",  # Replace with your client ID
-                # issuer=""  # Replace with your IdP's issuer URL
-            )
-            return payload
-
-        except ExpiredSignatureError:
-            raise Exception("Token has expired")
-        except InvalidTokenError as e:
-            raise Exception(f"Invalid token: {str(e)}")
-        except Exception as e:
-            raise Exception(f"Error validating token: {str(e)}")
+        payload = jwt.decode(
+            token,
+            public_key,
+            options={
+                "verify_signature": True,
+                "verify_exp": True,
+                "verify_aud": False,
+                "verify_iat": True,
+                "verify_iss": True,
+                "require": ["exp", "iat", "iss"],
+            },
+        )
+        return payload

--- a/src/mcpengine/server/auth/backend.py
+++ b/src/mcpengine/server/auth/backend.py
@@ -13,6 +13,7 @@ from urllib.parse import urljoin
 
 import httpx
 import jwt
+from jwt import InvalidTokenError
 from pydantic.networks import HttpUrl
 from starlette.authentication import (
     AuthenticationError,
@@ -182,12 +183,12 @@ class BearerTokenBackend(AuthenticationBackend):
         try:
             header = jwt.get_unverified_header(token)
         except Exception as e:
-            raise Exception(f"Error decoding token header: {str(e)}")
+            raise InvalidTokenError(f"Error decoding token header: {str(e)}")
 
         # Get the key id from header
         kid = header.get("kid")
         if not kid:
-            raise Exception("Token header missing 'kid' claim")
+            raise InvalidTokenError("Token header missing 'kid' claim")
 
         # Find the matching key in the JWKS
         rsa_key = None

--- a/src/mcpengine/server/auth/backend.py
+++ b/src/mcpengine/server/auth/backend.py
@@ -152,8 +152,6 @@ class BearerTokenBackend(AuthenticationBackend):
                 sid=decoded_token.get("sid", None),
                 token=token,
             )
-
-            None
         except (AuthenticationError, AuthorizationError) as e:
             raise e
         except Exception as err:

--- a/src/mcpengine/server/auth/backend.py
+++ b/src/mcpengine/server/auth/backend.py
@@ -16,10 +16,7 @@ import jwt
 from jwt.exceptions import ExpiredSignatureError, InvalidTokenError
 from pydantic.networks import HttpUrl
 from starlette.authentication import (
-    AuthCredentials,
     AuthenticationError,
-    BaseUser,
-    SimpleUser,
 )
 from starlette.requests import Request
 from starlette.responses import Response
@@ -48,7 +45,6 @@ def get_auth_backend(
         scopes_mapping=scopes_mapping,
         scopes=scopes,
     )
-
 
 
 class AuthenticationBackend(Protocol):
@@ -201,7 +197,9 @@ class BearerTokenBackend(AuthenticationBackend):
         # Prepare the public key for verification
         try:
             # Convert the JWK to a format PyJWT can use
-            public_key = jwt.get_algorithm_by_name("RS256").from_jwk(json.dumps(rsa_key))
+            public_key = jwt.get_algorithm_by_name("RS256").from_jwk(
+                json.dumps(rsa_key)
+            )
         except Exception as e:
             raise Exception(f"Error preparing public key: {str(e)}")
 
@@ -230,4 +228,3 @@ class BearerTokenBackend(AuthenticationBackend):
             raise Exception(f"Invalid token: {str(e)}")
         except Exception as e:
             raise Exception(f"Error validating token: {str(e)}")
-

--- a/src/mcpengine/server/auth/backend.py
+++ b/src/mcpengine/server/auth/backend.py
@@ -198,7 +198,7 @@ class BearerTokenBackend(AuthenticationBackend):
                 break
 
         if not rsa_key:
-            raise Exception(f"No matching key found for kid: {kid}")
+            raise KeyError(f"No matching key found for kid: {kid}")
 
         # Needed to satisfy the type checker.
         # If this is not None (which we check above), then this field
@@ -212,7 +212,7 @@ class BearerTokenBackend(AuthenticationBackend):
                 json.dumps(rsa_key)
             )
         except Exception as e:
-            raise Exception(f"Error preparing public key: {str(e)}")
+            raise InvalidTokenError(f"Error preparing public key: {str(e)}")
 
         payload = jwt.decode(
             token,

--- a/src/mcpengine/server/auth/backend.py
+++ b/src/mcpengine/server/auth/backend.py
@@ -13,7 +13,6 @@ from urllib.parse import urljoin
 
 import httpx
 import jwt
-from jwt.exceptions import ExpiredSignatureError, InvalidTokenError
 from pydantic.networks import HttpUrl
 from starlette.authentication import (
     AuthenticationError,
@@ -204,6 +203,7 @@ class BearerTokenBackend(AuthenticationBackend):
         payload = jwt.decode(
             token,
             public_key,
+            algorithms=jwt.algorithms.get_default_algorithms(),
             options={
                 "verify_signature": True,
                 "verify_exp": True,

--- a/src/mcpengine/server/auth/backend.py
+++ b/src/mcpengine/server/auth/backend.py
@@ -38,7 +38,7 @@ OAUTH_WELL_KNOWN_PATH: str = ".well-known/oauth-authorization-server"
 
 # TODO: Not Any
 def get_auth_backend(
-        settings: Any, scopes: set[str], scopes_mapping: dict[str, set[str]]
+    settings: Any, scopes: set[str], scopes_mapping: dict[str, set[str]]
 ) -> AuthenticationBackend:
     if not settings.authentication_enabled:
         return NoAuthBackend()
@@ -107,9 +107,9 @@ def validate_token(jwks: list[dict[str, object]], token: str) -> Any:
 
 class AuthenticationBackend(Protocol):
     async def authenticate(
-            self,
-            request: Request,
-            message: JSONRPCMessage,
+        self,
+        request: Request,
+        message: JSONRPCMessage,
     ) -> tuple[AuthCredentials, BaseUser] | None: ...
 
     def on_error(self, err: Exception) -> Response: ...
@@ -120,9 +120,9 @@ class NoAuthBackend(AuthenticationBackend):
         pass
 
     async def authenticate(
-            self,
-            request: Request,
-            message: JSONRPCMessage,
+        self,
+        request: Request,
+        message: JSONRPCMessage,
     ) -> tuple[AuthCredentials, BaseUser] | None:
         return None
 
@@ -144,7 +144,7 @@ class BearerTokenBackend(AuthenticationBackend):
     scopes_mapping: dict[str, set[str]]
 
     def __init__(
-            self, issuer_url: HttpUrl, scopes: set[str], scopes_mapping: dict[str, set[str]]
+        self, issuer_url: HttpUrl, scopes: set[str], scopes_mapping: dict[str, set[str]]
     ) -> None:
         self.issuer_url = issuer_url
         self.application_scopes = scopes
@@ -163,9 +163,9 @@ class BearerTokenBackend(AuthenticationBackend):
         )
 
     async def authenticate(
-            self,
-            request: Request,
-            message: JSONRPCMessage,
+        self,
+        request: Request,
+        message: JSONRPCMessage,
     ) -> tuple[AuthCredentials, BaseUser] | None:
         if not isinstance(message.root, mcpengine.JSONRPCRequest):
             return None
@@ -195,13 +195,11 @@ class BearerTokenBackend(AuthenticationBackend):
             needed_scopes: set[str] = set()
             if req_message.params and "name" in req_message.params:
                 needed_scopes = self.scopes_mapping.get(
-                    req_message.params["name"],
-                    set()
+                    req_message.params["name"], set()
                 )
             if needed_scopes.difference(scopes):
                 raise AuthorizationError(
-                    f"Invalid auth scopes, needed: {needed_scopes}, "
-                    f"received: {scopes}"
+                    f"Invalid auth scopes, needed: {needed_scopes}, received: {scopes}"
                 )
 
             if req_message.params is None:

--- a/src/mcpengine/server/auth/backend.py
+++ b/src/mcpengine/server/auth/backend.py
@@ -191,10 +191,15 @@ class BearerTokenBackend(AuthenticationBackend):
         if not rsa_key:
             raise Exception(f"No matching key found for kid: {kid}")
 
+        # Needed to satisfy the type checker.
+        # If this is not None (which we check above), then this field
+        # will have the name of the algorithm used for the key.
+        algorithm = str(rsa_key["alg"])
+
         # Prepare the public key for verification
         try:
             # Convert the JWK to a format PyJWT can use
-            public_key = jwt.get_algorithm_by_name("RS256").from_jwk(
+            public_key = jwt.get_algorithm_by_name(algorithm).from_jwk(
                 json.dumps(rsa_key)
             )
         except Exception as e:
@@ -203,7 +208,7 @@ class BearerTokenBackend(AuthenticationBackend):
         payload = jwt.decode(
             token,
             public_key,
-            algorithms=jwt.algorithms.get_default_algorithms(),
+            algorithms=algorithm,
             options={
                 "verify_signature": True,
                 "verify_exp": True,

--- a/src/mcpengine/server/auth/context.py
+++ b/src/mcpengine/server/auth/context.py
@@ -11,3 +11,4 @@ class UserContext:
     name: str | None
     email: str | None
     sid: str | None
+    token: str | None

--- a/src/mcpengine/server/auth/errors.py
+++ b/src/mcpengine/server/auth/errors.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2025 Featureform, Inc.
+#
+# Licensed under the MIT License. See LICENSE file in the
+# project root for full license information.
+
+
+class AuthorizationError(Exception):
+    pass

--- a/src/mcpengine/server/lowlevel/server.py
+++ b/src/mcpengine/server/lowlevel/server.py
@@ -558,6 +558,7 @@ class Server(Generic[LifespanResultT]):
                         lifespan_context=lifespan_context,
                         user_id=user_context.get("sid"),
                         user_name=user_context.get("name"),
+                        token=user_context.get("token"),
                     )
                 )
                 response = await handler(req)

--- a/src/mcpengine/server/mcpengine/server.py
+++ b/src/mcpengine/server/mcpengine/server.py
@@ -716,9 +716,9 @@ class Context(BaseModel, Generic[ServerSessionT, LifespanContextT]):
         Returns:
             The resource content as either text or bytes
         """
-        assert (
-            self._mcpengine is not None
-        ), "Context is not available outside of a request"
+        assert self._mcpengine is not None, (
+            "Context is not available outside of a request"
+        )
         return await self._mcpengine.read_resource(uri)
 
     async def log(

--- a/src/mcpengine/server/mcpengine/server.py
+++ b/src/mcpengine/server/mcpengine/server.py
@@ -763,6 +763,10 @@ class Context(BaseModel, Generic[ServerSessionT, LifespanContextT]):
         return str(self.request_context.user_name)
 
     @property
+    def token(self) -> str:
+        return self.request_context.token
+
+    @property
     def session(self):
         """Access to the underlying session for advanced usage."""
         return self.request_context.session

--- a/src/mcpengine/server/mcpengine/server.py
+++ b/src/mcpengine/server/mcpengine/server.py
@@ -764,7 +764,7 @@ class Context(BaseModel, Generic[ServerSessionT, LifespanContextT]):
 
     @property
     def token(self) -> str:
-        return self.request_context.token
+        return str(self.request_context.token)
 
     @property
     def session(self):

--- a/src/mcpengine/server/sse.py
+++ b/src/mcpengine/server/sse.py
@@ -180,6 +180,24 @@ class SseServerTransport:
             await writer.send(err)
             return
 
+        err_response = await self.validate_auth(
+            request,
+            message,
+        )
+        if err_response:
+            await err_response(scope, receive, send)
+            return
+
+        logger.debug(f"Sending message to writer: {message}")
+        response = Response("Accepted", status_code=202)
+        await response(scope, receive, send)
+        await writer.send(message)
+
+    async def validate_auth(
+            self,
+            request: Request,
+            message: types.JSONRPCMessage,
+    ) -> Response | None:
         if self._auth_backend:
             logger.debug("authentication backend configured for SseServerTransport")
             try:
@@ -187,10 +205,4 @@ class SseServerTransport:
             except Exception as e:
                 logger.error(f"Failed to authenticate: {e}")
                 response = self._auth_backend.on_error(e)
-                await response(scope, receive, send)
-                return
-
-        logger.debug(f"Sending message to writer: {message}")
-        response = Response("Accepted", status_code=202)
-        await response(scope, receive, send)
-        await writer.send(message)
+                return response

--- a/src/mcpengine/server/sse.py
+++ b/src/mcpengine/server/sse.py
@@ -194,9 +194,9 @@ class SseServerTransport:
         await writer.send(message)
 
     async def validate_auth(
-            self,
-            request: Request,
-            message: types.JSONRPCMessage,
+        self,
+        request: Request,
+        message: types.JSONRPCMessage,
     ) -> Response | None:
         if self._auth_backend:
             logger.debug("authentication backend configured for SseServerTransport")

--- a/src/mcpengine/server/sse.py
+++ b/src/mcpengine/server/sse.py
@@ -181,9 +181,7 @@ class SseServerTransport:
             return
 
         if self._auth_backend:
-            logger.debug(
-                "authentication backend configured for SseServerTransport"
-            )
+            logger.debug("authentication backend configured for SseServerTransport")
             try:
                 await self._auth_backend.authenticate(request, message)
             except Exception as e:

--- a/src/mcpengine/shared/context.py
+++ b/src/mcpengine/shared/context.py
@@ -24,3 +24,4 @@ class RequestContext(Generic[SessionT, LifespanContextT]):
     lifespan_context: LifespanContextT
     user_id: str | None = None
     user_name: str | None = None
+    token: str | None = None

--- a/src/mcpengine/shared/memory.py
+++ b/src/mcpengine/shared/memory.py
@@ -27,9 +27,9 @@ MessageStream = tuple[
 
 
 @asynccontextmanager
-async def create_client_server_memory_streams() -> (
-    AsyncGenerator[tuple[MessageStream, MessageStream], None]
-):
+async def create_client_server_memory_streams() -> AsyncGenerator[
+    tuple[MessageStream, MessageStream], None
+]:
     """
     Creates a pair of bidirectional memory streams for client-server communication.
 

--- a/tests/server/auth/test_return_code.py
+++ b/tests/server/auth/test_return_code.py
@@ -52,6 +52,7 @@ async def test_unauthenticated_return_code(mock_bearer_token_backend):
     )
 
     response = await transport.validate_auth(request, message)
+    assert response is not None
     assert response.status_code == 401
 
 
@@ -94,4 +95,5 @@ async def test_unauthorized_return_code(mock_bearer_token_backend):
         params={"name": "required-scope"},
     )
     response = await transport.validate_auth(request, message)
+    assert response is not None
     assert response.status_code == 403

--- a/tests/server/auth/test_return_code.py
+++ b/tests/server/auth/test_return_code.py
@@ -1,0 +1,97 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import HttpUrl
+
+from mcpengine.server.auth.backend import BearerTokenBackend
+from mcpengine.server.sse import SseServerTransport
+from mcpengine.types import JSONRPCRequest
+
+
+@pytest.fixture
+def mock_bearer_token_backend():
+    def _create_mock(application_scopes, scopes_mapping, token):
+        backend = BearerTokenBackend(
+            issuer_url=HttpUrl("http://some-issuer"),
+            scopes=application_scopes,
+            scopes_mapping=scopes_mapping,
+        )
+
+        backend._get_jwks = AsyncMock(return_value=None)
+
+        validate_token_mock = MagicMock()
+        validate_token_mock.return_value = token
+        backend.validate_token = validate_token_mock
+
+        return backend
+
+    return _create_mock
+
+
+@pytest.mark.anyio
+async def test_unauthenticated_return_code(mock_bearer_token_backend):
+    backend = mock_bearer_token_backend(
+        application_scopes=[],
+        scopes_mapping={},
+        token=None,
+    )
+    transport = SseServerTransport(
+        "",
+        backend,
+    )
+
+    request = MagicMock()
+    request.headers = {}
+
+    message = MagicMock()
+    message.root = JSONRPCRequest(
+        jsonrpc="2.0",
+        id="",
+        method="tools/call",
+        params={},
+    )
+
+    response = await transport.validate_auth(request, message)
+    assert response.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_unauthorized_return_code(mock_bearer_token_backend):
+    backend = mock_bearer_token_backend(
+        application_scopes=["example-scope"],
+        scopes_mapping={
+            "required-scope": {"example-scope"},
+            "no-scopes-required": set(),
+        },
+        token={
+            "scope": "",
+        },
+    )
+    transport = SseServerTransport(
+        "",
+        backend,
+    )
+
+    request = MagicMock()
+    request.headers = {"Authorization": 'Bearer "hello_world"'}
+
+    message = MagicMock()
+    message.root = JSONRPCRequest(
+        jsonrpc="2.0",
+        id="",
+        method="tools/call",
+        params={"name": "no-scopes-required"},
+    )
+
+    response = await transport.validate_auth(request, message)
+    assert response is None
+
+    message = MagicMock()
+    message.root = JSONRPCRequest(
+        jsonrpc="2.0",
+        id="",
+        method="tools/call",
+        params={"name": "required-scope"},
+    )
+    response = await transport.validate_auth(request, message)
+    assert response.status_code == 403

--- a/tests/server/mcpengine/test_server.py
+++ b/tests/server/mcpengine/test_server.py
@@ -281,7 +281,9 @@ class TestServerResources:
             return "Hello, world!"
 
         resource = FunctionResource(
-            uri=AnyUrl("resource://test"), name="test", fn=get_text,
+            uri=AnyUrl("resource://test"),
+            name="test",
+            fn=get_text,
         )
         mcp.add_resource(resource)
 


### PR DESCRIPTION
- When the user doesn't have the required scopes in order to call a handler, we now return a 403 instead of a 401.
- Additionally, inject the (valid) token so that handlers can pull it from the context.