### PR TITLE
Change auth flow to PKCE

### DIFF
--- a/mcpengine-proxy/auth_test.go
+++ b/mcpengine-proxy/auth_test.go
@@ -40,6 +40,7 @@ func TestResolveConfig(t *testing.T) {
 			},
 			expected: &AuthConfig{
 				ClientID:           "test-client",
+				ClientSecret:       "",
 				ListenPort:         8181,
 				CallbackPath:       "/callback",
 				OIDCConfigPath:     "/.well-known/openid-configuration",
@@ -51,6 +52,7 @@ func TestResolveConfig(t *testing.T) {
 			name: "complete custom config",
 			input: &AuthConfig{
 				ClientID:           "test-client",
+				ClientSecret:       "test-secret",
 				ListenPort:         9000,
 				CallbackPath:       "/custom-callback",
 				OIDCConfigPath:     "/custom-config",
@@ -59,6 +61,7 @@ func TestResolveConfig(t *testing.T) {
 			},
 			expected: &AuthConfig{
 				ClientID:           "test-client",
+				ClientSecret:       "test-secret",
 				ListenPort:         9000,
 				CallbackPath:       "/custom-callback",
 				OIDCConfigPath:     "/custom-config",
@@ -92,18 +95,27 @@ func TestNewAuthManager(t *testing.T) {
 		if auth.redirectURL != "http://localhost:8181/callback" {
 			t.Errorf("Expected redirectURL to be http://localhost:8181/callback, got %s", auth.redirectURL)
 		}
+
+		if auth.clientID != "" || auth.clientSecret != "" {
+			t.Errorf("Expected empty clientID/secret, got %s/%s", auth.clientID, auth.clientSecret)
+		}
 	})
 
 	t.Run("with custom config", func(t *testing.T) {
 		config := &AuthConfig{
-			ClientID:   "client-123",
-			ListenPort: 9999,
+			ClientID:     "client-123",
+			ClientSecret: "secret-456",
+			ListenPort:   9999,
 		}
 
 		auth := NewAuthManager(config, logger)
 
 		if auth.clientID != "client-123" {
 			t.Errorf("Expected clientID to be client-123, got %s", auth.clientID)
+		}
+
+		if auth.clientSecret != "secret-456" {
+			t.Errorf("Expected clientSecret to be secret-456, got %s", auth.clientSecret)
 		}
 
 		if auth.redirectURL != "http://localhost:9999/callback" {
@@ -416,6 +428,10 @@ func TestInitOAuth2Config(t *testing.T) {
 
 	if auth.oauth2Config.ClientID != "test-client" {
 		t.Errorf("Wrong client ID: %s", auth.oauth2Config.ClientID)
+	}
+
+	if auth.oauth2Config.ClientSecret != "" {
+		t.Errorf("Wrong client secret: %s", auth.oauth2Config.ClientSecret)
 	}
 
 	if auth.oauth2Config.RedirectURL != "http://localhost:8181/callback" {

--- a/mcpengine-proxy/auth_test.go
+++ b/mcpengine-proxy/auth_test.go
@@ -36,12 +36,10 @@ func TestResolveConfig(t *testing.T) {
 		{
 			name: "partial config",
 			input: &AuthConfig{
-				ClientID:     "test-client",
-				ClientSecret: "test-secret",
+				ClientID: "test-client",
 			},
 			expected: &AuthConfig{
 				ClientID:           "test-client",
-				ClientSecret:       "test-secret",
 				ListenPort:         8181,
 				CallbackPath:       "/callback",
 				OIDCConfigPath:     "/.well-known/openid-configuration",
@@ -53,7 +51,6 @@ func TestResolveConfig(t *testing.T) {
 			name: "complete custom config",
 			input: &AuthConfig{
 				ClientID:           "test-client",
-				ClientSecret:       "test-secret",
 				ListenPort:         9000,
 				CallbackPath:       "/custom-callback",
 				OIDCConfigPath:     "/custom-config",
@@ -62,7 +59,6 @@ func TestResolveConfig(t *testing.T) {
 			},
 			expected: &AuthConfig{
 				ClientID:           "test-client",
-				ClientSecret:       "test-secret",
 				ListenPort:         9000,
 				CallbackPath:       "/custom-callback",
 				OIDCConfigPath:     "/custom-config",
@@ -96,27 +92,18 @@ func TestNewAuthManager(t *testing.T) {
 		if auth.redirectURL != "http://localhost:8181/callback" {
 			t.Errorf("Expected redirectURL to be http://localhost:8181/callback, got %s", auth.redirectURL)
 		}
-
-		if auth.clientID != "" || auth.clientSecret != "" {
-			t.Errorf("Expected empty clientID/secret, got %s/%s", auth.clientID, auth.clientSecret)
-		}
 	})
 
 	t.Run("with custom config", func(t *testing.T) {
 		config := &AuthConfig{
-			ClientID:     "client-123",
-			ClientSecret: "secret-456",
-			ListenPort:   9999,
+			ClientID:   "client-123",
+			ListenPort: 9999,
 		}
 
 		auth := NewAuthManager(config, logger)
 
 		if auth.clientID != "client-123" {
 			t.Errorf("Expected clientID to be client-123, got %s", auth.clientID)
-		}
-
-		if auth.clientSecret != "secret-456" {
-			t.Errorf("Expected clientSecret to be secret-456, got %s", auth.clientSecret)
 		}
 
 		if auth.redirectURL != "http://localhost:9999/callback" {
@@ -408,8 +395,7 @@ func TestFetchOIDCConfiguration(t *testing.T) {
 func TestInitOAuth2Config(t *testing.T) {
 	logger := zap.NewNop().Sugar()
 	auth := NewAuthManager(&AuthConfig{
-		ClientID:     "test-client",
-		ClientSecret: "test-secret",
+		ClientID: "test-client",
 	}, logger)
 
 	// Set up OIDC config
@@ -430,10 +416,6 @@ func TestInitOAuth2Config(t *testing.T) {
 
 	if auth.oauth2Config.ClientID != "test-client" {
 		t.Errorf("Wrong client ID: %s", auth.oauth2Config.ClientID)
-	}
-
-	if auth.oauth2Config.ClientSecret != "test-secret" {
-		t.Errorf("Wrong client secret: %s", auth.oauth2Config.ClientSecret)
 	}
 
 	if auth.oauth2Config.RedirectURL != "http://localhost:8181/callback" {
@@ -476,8 +458,7 @@ func TestHandleAuthChallenge(t *testing.T) {
 
 	logger := zap.NewNop().Sugar()
 	auth := NewAuthManager(&AuthConfig{
-		ClientID:     "test-client",
-		ClientSecret: "test-secret",
+		ClientID: "test-client",
 		// Use small values for testing
 		MaxAuthAttempts:    1,
 		AuthCooldownPeriod: 50 * time.Millisecond,

--- a/mcpengine-proxy/cmd/main.go
+++ b/mcpengine-proxy/cmd/main.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"flag"
+	"fmt"
 	"os"
 
 	"go.uber.org/zap"
@@ -14,7 +14,6 @@ import (
 func main() {
 	host := flag.String("host", "localhost:8000", "The hostname. By default we connect to <hostname>/sse")
 	clientId := flag.String("client_id", "", "The ClientID to be used in OAuth")
-	clientSecret := flag.String("client_secret", "", "The Client Secret to be used in OAuth")
 	ssePath := flag.String("sse_path", "/sse", "The path to append to hostname for an /sse connection")
 	debug := flag.Bool("debug", false, "Enable debug logging")
 	flag.Parse()
@@ -42,10 +41,9 @@ func main() {
 	}
 	engine, err := mcpengine.New(mcpengine.Config{
 		Endpoint: *host,
-		SSEPath: *ssePath,
+		SSEPath:  *ssePath,
 		AuthConfig: &mcpengine.AuthConfig{
 			ClientID: *clientId,
-			ClientSecret: *clientSecret,
 		},
 		Logger: logger,
 	})

--- a/mcpengine-proxy/cmd/main.go
+++ b/mcpengine-proxy/cmd/main.go
@@ -14,6 +14,7 @@ import (
 func main() {
 	host := flag.String("host", "localhost:8000", "The hostname. By default we connect to <hostname>/sse")
 	clientId := flag.String("client_id", "", "The ClientID to be used in OAuth")
+	clientSecret := flag.String("client_secret", "", "The Client Secret to be used in OAuth (can be empty if using PKCE)")
 	ssePath := flag.String("sse_path", "/sse", "The path to append to hostname for an /sse connection")
 	debug := flag.Bool("debug", false, "Enable debug logging")
 	flag.Parse()
@@ -43,7 +44,8 @@ func main() {
 		Endpoint: *host,
 		SSEPath:  *ssePath,
 		AuthConfig: &mcpengine.AuthConfig{
-			ClientID: *clientId,
+			ClientID:     *clientId,
+			ClientSecret: *clientSecret,
 		},
 		Logger: logger,
 	})


### PR DESCRIPTION
Change the authorization flow in the MCP Proxy to use authorization code with PKCE. This is in line with that the [specification requires for clients](https://modelcontextprotocol.io/specification/2025-03-26/basic/authorization#2-9-implementation-requirements), since mcp clients should be seen as public clients. This also then removes the client-secret that was previously required in the proxy.