### PR TITLE
Refactor IdP configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,11 +95,13 @@ Enable OAuth and scopes:
 
 ```python
 from mcpengine import MCPEngine, Context
+from mcpengine.server.auth.providers.config import IdpConfig
 
 mcp = MCPEngine(
     "SecureDemo",
-    authentication_enabled=True,
-    issuer_url="https://your-idp.example.com/realms/some-realm",
+    idp_config=IdpConfig(
+        issuer_url="https://your-idp.example.com/realms/some-realm",
+    ),
 )
 
 
@@ -190,11 +192,13 @@ Each request has a Context:
 ```python
 import sqlite3
 from mcpengine import MCPEngine, Context
+from mcpengine.server.auth.providers.config import IdpConfig
 
 mcp = MCPEngine(
     "SQLiteExplorer",
-    authentication_enabled=True,
-    issuer_url="https://your-idp.example.com/realms/some-realm",
+    idp_config=IdpConfig(
+        issuer_url="https://your-idp.example.com/realms/some-realm",
+    ),
 )
 
 

--- a/examples/servers/smack/mcp_smack/server.py
+++ b/examples/servers/smack/mcp_smack/server.py
@@ -18,6 +18,7 @@ from contextlib import asynccontextmanager
 from dataclasses import dataclass
 
 from mcpengine import Context, MCPEngine
+from mcpengine.server.auth.providers.config import IdpConfig
 
 from .db import MessageDB
 
@@ -65,8 +66,9 @@ async def app_lifespan(server: MCPEngine) -> AsyncIterator[AppContext]:
 mcp = MCPEngine(
     "smack",
     lifespan=app_lifespan,
-    authentication_enabled=True,
-    issuer_url="http://localhost:8080/realms/master",
+    idp_config=IdpConfig(
+        issuer_url="http://localhost:8080/realms/master"
+    ),
 )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "pydantic-settings>=2.5.2",
     "uvicorn>=0.23.1",
     "pyjwt[crypto]==2.10.1",
+    "async-lru==2.0.5",
 ]
 
 [project.optional-dependencies]

--- a/src/mcpengine/server/auth/backend.py
+++ b/src/mcpengine/server/auth/backend.py
@@ -9,36 +9,31 @@ from __future__ import annotations as _annotations
 
 import json
 from typing import Any, Protocol
-from urllib.parse import urljoin
 
-import httpx
 import jwt
 from jwt import InvalidTokenError
-from pydantic.networks import HttpUrl
 from starlette.requests import Request
 from starlette.responses import Response
 
 import mcpengine
 from mcpengine.server.auth.context import UserContext
 from mcpengine.server.auth.errors import AuthenticationError, AuthorizationError
+from mcpengine.server.auth.providers.config import IdpConfig
 from mcpengine.server.mcpengine.utilities.logging import get_logger
 from mcpengine.types import JSONRPCMessage
 
 logger = get_logger(__name__)
-
-OPENID_WELL_KNOWN_PATH: str = ".well-known/openid-configuration"
-OAUTH_WELL_KNOWN_PATH: str = ".well-known/oauth-authorization-server"
 
 
 # TODO: Not Any
 def get_auth_backend(
     settings: Any, scopes: set[str], scopes_mapping: dict[str, set[str]]
 ) -> AuthenticationBackend:
-    if not settings.authentication_enabled:
+    if not settings.idp_config:
         return NoAuthBackend()
 
     return BearerTokenBackend(
-        issuer_url=settings.issuer_url,
+        idp_config=settings.idp_config,
         scopes_mapping=scopes_mapping,
         scopes=scopes,
     )
@@ -78,19 +73,28 @@ class BearerTokenBackend(AuthenticationBackend):
         "prompts/get",
     }
 
-    issuer_url: HttpUrl
+    idp_config: IdpConfig
     application_scopes: set[str]
     scopes_mapping: dict[str, set[str]]
 
     def __init__(
-        self, issuer_url: HttpUrl, scopes: set[str], scopes_mapping: dict[str, set[str]]
+        self, idp_config: IdpConfig, scopes: set[str], scopes_mapping: dict[str, set[str]]
     ) -> None:
-        self.issuer_url = issuer_url
+        self.idp_config = idp_config
         self.application_scopes = scopes
         self.scopes_mapping = scopes_mapping
 
     def on_error(self, err: Exception) -> Response:
-        bearer = f'Bearer scope="{" ".join(self.application_scopes)}"'
+        scopes = self.application_scopes
+
+        # It's an error to have an empty scopes parameter in an OAuth flow.
+        # In the case the application doesn't request any, we include the
+        # "openid" scope, which is the most minimal scope for OIDC there is
+        # (and most OAuth IdPs should also support it).
+        if len(scopes) == 0:
+            scopes = ["openid"]
+        bearer = f'Bearer scope="{" ".join(scopes)}"'
+
         if isinstance(err, AuthorizationError):
             status_code = 403
         else:
@@ -134,9 +138,22 @@ class BearerTokenBackend(AuthenticationBackend):
             raise AuthenticationError("Invalid credentials") from err
 
     async def _decode_token(self, token: str) -> Any:
-        jwks = await self._get_jwks()
-        decoded_token = self.validate_token(jwks, token)
-        return decoded_token
+        # First, try to see if it's a JWT, and decode it.
+        try:
+            jwks = await self.idp_config.get_jwks()
+            decoded_token = self.validate_token(jwks, token)
+            return decoded_token
+        except Exception:
+            pass
+
+        # If not, try the token introspection endpoint (as defined by RFC 7662)
+        try:
+            result = await self.idp_config.validate_token(token)
+            return result
+        except Exception:
+            pass
+
+        raise AuthenticationError("Could not verify token")
 
     def _validate_scopes(self, message: mcpengine.JSONRPCRequest, decoded_token: Any):
         scopes = decoded_token.get("scope", set())
@@ -161,19 +178,6 @@ class BearerTokenBackend(AuthenticationBackend):
         if scheme.lower() != "bearer":
             raise AuthenticationError(f'Invalid auth schema "{scheme}", must be Bearer')
         return token
-
-    async def _get_jwks(self) -> Any:
-        # TODO: Cache this stuff
-        async with httpx.AsyncClient() as client:
-            issuer_url = str(self.issuer_url).rstrip("/") + "/"
-            well_known_url = urljoin(issuer_url, OAUTH_WELL_KNOWN_PATH)
-            response = await client.get(well_known_url)
-
-            jwks_url = response.json()["jwks_uri"]
-            response = await client.get(jwks_url)
-            jwks_keys = response.json()["keys"]
-
-            return jwks_keys
 
     @staticmethod
     def validate_token(jwks: list[dict[str, object]], token: str) -> Any:

--- a/src/mcpengine/server/auth/backend.py
+++ b/src/mcpengine/server/auth/backend.py
@@ -78,7 +78,10 @@ class BearerTokenBackend(AuthenticationBackend):
     scopes_mapping: dict[str, set[str]]
 
     def __init__(
-        self, idp_config: IdpConfig, scopes: set[str], scopes_mapping: dict[str, set[str]]
+        self,
+        idp_config: IdpConfig,
+        scopes: set[str],
+        scopes_mapping: dict[str, set[str]],
     ) -> None:
         self.idp_config = idp_config
         self.application_scopes = scopes

--- a/src/mcpengine/server/auth/providers/__init__.py
+++ b/src/mcpengine/server/auth/providers/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2025 Featureform, Inc.
+#
+# Licensed under the MIT License. See LICENSE file in the
+# project root for full license information.

--- a/src/mcpengine/server/auth/providers/config.py
+++ b/src/mcpengine/server/auth/providers/config.py
@@ -11,15 +11,12 @@ from async_lru import alru_cache
 OPENID_WELL_KNOWN_PATH: str = ".well-known/openid-configuration"
 OAUTH_WELL_KNOWN_PATH: str = ".well-known/oauth-authorization-server"
 
+
 class IdpConfig:
     issuer_url: str
     token_validation_endpoint: str | None
 
-    def __init__(
-            self,
-            issuer_url: str ,
-            token_validation_endpoint: str | None = None
-    ):
+    def __init__(self, issuer_url: str, token_validation_endpoint: str | None = None):
         super().__init__()
         self.issuer_url = issuer_url
         self.token_validation_endpoint = token_validation_endpoint
@@ -38,7 +35,6 @@ class IdpConfig:
                     continue
 
                 return response.json()
-
 
     @alru_cache()
     async def get_jwks(self) -> Any:

--- a/src/mcpengine/server/auth/providers/config.py
+++ b/src/mcpengine/server/auth/providers/config.py
@@ -7,19 +7,18 @@ from urllib.parse import urljoin
 
 import httpx
 from async_lru import alru_cache
-from pydantic import AnyHttpUrl
 
 OPENID_WELL_KNOWN_PATH: str = ".well-known/openid-configuration"
 OAUTH_WELL_KNOWN_PATH: str = ".well-known/oauth-authorization-server"
 
 class IdpConfig:
-    issuer_url: AnyHttpUrl
-    token_validation_endpoint: AnyHttpUrl | None
+    issuer_url: str
+    token_validation_endpoint: str | None
 
     def __init__(
             self,
-            issuer_url: AnyHttpUrl,
-            token_validation_endpoint: AnyHttpUrl | None = None
+            issuer_url: str ,
+            token_validation_endpoint: str | None = None
     ):
         super().__init__()
         self.issuer_url = issuer_url

--- a/src/mcpengine/server/auth/providers/config.py
+++ b/src/mcpengine/server/auth/providers/config.py
@@ -11,6 +11,8 @@ from async_lru import alru_cache
 OPENID_WELL_KNOWN_PATH: str = ".well-known/openid-configuration"
 OAUTH_WELL_KNOWN_PATH: str = ".well-known/oauth-authorization-server"
 
+METADATA_CACHE_TTL = 300  # in seconds
+
 
 class IdpConfig:
     issuer_url: str
@@ -21,7 +23,7 @@ class IdpConfig:
         self.issuer_url = issuer_url
         self.token_validation_endpoint = token_validation_endpoint
 
-    @alru_cache()
+    @alru_cache(ttl=METADATA_CACHE_TTL)
     async def get_metadata(self) -> Any:
         endpoints = [OPENID_WELL_KNOWN_PATH, OAUTH_WELL_KNOWN_PATH]
         issuer_url = str(self.issuer_url).rstrip("/") + "/"
@@ -36,7 +38,7 @@ class IdpConfig:
 
                 return response.json()
 
-    @alru_cache()
+    @alru_cache(ttl=METADATA_CACHE_TTL)
     async def get_jwks(self) -> Any:
         metadata = await self.get_metadata()
         async with httpx.AsyncClient() as client:

--- a/src/mcpengine/server/auth/providers/config.py
+++ b/src/mcpengine/server/auth/providers/config.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2025 Featureform, Inc.
+#
+# Licensed under the MIT License. See LICENSE file in the
+# project root for full license information.
+from typing import Any
+from urllib.parse import urljoin
+
+import httpx
+from async_lru import alru_cache
+from pydantic import AnyHttpUrl
+
+OPENID_WELL_KNOWN_PATH: str = ".well-known/openid-configuration"
+OAUTH_WELL_KNOWN_PATH: str = ".well-known/oauth-authorization-server"
+
+class IdpConfig:
+    issuer_url: AnyHttpUrl
+    token_validation_endpoint: AnyHttpUrl | None
+
+    def __init__(
+            self,
+            issuer_url: AnyHttpUrl,
+            token_validation_endpoint: AnyHttpUrl | None = None
+    ):
+        super().__init__()
+        self.issuer_url = issuer_url
+        self.token_validation_endpoint = token_validation_endpoint
+
+    @alru_cache()
+    async def get_metadata(self) -> Any:
+        endpoints = [OPENID_WELL_KNOWN_PATH, OAUTH_WELL_KNOWN_PATH]
+        issuer_url = str(self.issuer_url).rstrip("/") + "/"
+
+        async with httpx.AsyncClient() as client:
+            for endpoint in endpoints:
+                well_known_url = urljoin(issuer_url, endpoint)
+                response = await client.get(well_known_url)
+
+                if response.status_code >= 400:
+                    continue
+
+                return response.json()
+
+
+    @alru_cache()
+    async def get_jwks(self) -> Any:
+        metadata = await self.get_metadata()
+        async with httpx.AsyncClient() as client:
+            jwks_url = metadata["jwks_uri"]
+            response = await client.get(jwks_url)
+            jwks_keys = response.json()["keys"]
+
+            return jwks_keys
+
+    async def validate_token(self, token: str) -> dict[str, Any]:
+        raise NotImplementedError()

--- a/src/mcpengine/server/auth/providers/google.py
+++ b/src/mcpengine/server/auth/providers/google.py
@@ -5,12 +5,11 @@
 from typing import Any
 
 import httpx
-from pydantic import AnyHttpUrl
 
 from mcpengine.server.auth.providers.config import IdpConfig
 
-ISSUER_URL: AnyHttpUrl = AnyHttpUrl("https://accounts.google.com")
-TOKEN_VALIDATION_ENDPOINT: AnyHttpUrl = AnyHttpUrl("https://oauth2.googleapis.com/tokeninfo")
+ISSUER_URL = "https://accounts.google.com"
+TOKEN_VALIDATION_ENDPOINT = "https://oauth2.googleapis.com/tokeninfo"
 
 class GoogleIdpConfig(IdpConfig):
     def __init__(self):

--- a/src/mcpengine/server/auth/providers/google.py
+++ b/src/mcpengine/server/auth/providers/google.py
@@ -11,6 +11,7 @@ from mcpengine.server.auth.providers.config import IdpConfig
 ISSUER_URL = "https://accounts.google.com"
 TOKEN_VALIDATION_ENDPOINT = "https://oauth2.googleapis.com/tokeninfo"
 
+
 class GoogleIdpConfig(IdpConfig):
     def __init__(self):
         super().__init__(ISSUER_URL)
@@ -18,7 +19,6 @@ class GoogleIdpConfig(IdpConfig):
     async def validate_token(self, token: str) -> dict[str, Any]:
         async with httpx.AsyncClient() as client:
             response = await client.get(
-                str(TOKEN_VALIDATION_ENDPOINT),
-                params={"access_token": token }
+                str(TOKEN_VALIDATION_ENDPOINT), params={"access_token": token}
             )
             return response.json()

--- a/src/mcpengine/server/auth/providers/google.py
+++ b/src/mcpengine/server/auth/providers/google.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2025 Featureform, Inc.
+#
+# Licensed under the MIT License. See LICENSE file in the
+# project root for full license information.
+from typing import Any
+
+import httpx
+from pydantic import AnyHttpUrl
+
+from mcpengine.server.auth.providers.config import IdpConfig
+
+ISSUER_URL: AnyHttpUrl = AnyHttpUrl("https://accounts.google.com")
+TOKEN_VALIDATION_ENDPOINT: AnyHttpUrl = AnyHttpUrl("https://oauth2.googleapis.com/tokeninfo")
+
+class GoogleIdpConfig(IdpConfig):
+    def __init__(self):
+        super().__init__(ISSUER_URL)
+
+    async def validate_token(self, token: str) -> dict[str, Any]:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(
+                str(TOKEN_VALIDATION_ENDPOINT),
+                params={"access_token": token }
+            )
+            return response.json()

--- a/src/mcpengine/server/mcpengine/server.py
+++ b/src/mcpengine/server/mcpengine/server.py
@@ -582,24 +582,17 @@ class MCPEngine:
                     self._mcp_server.create_initialization_options(),
                 )
 
-        async def handle_well_known(_: Request) -> Response:
-            async with httpx.AsyncClient() as client:
-                issuer_url = str(self.settings.idp_config.issuer_url).rstrip("/") + "/"
-                well_known_url = urljoin(issuer_url, OPENID_WELL_KNOWN_PATH)
-                response = await client.get(well_known_url)
-                return JSONResponse(response.json())
-
         middleware: Sequence[Middleware] = []
 
         routes = [
             Route(
                 f"/{OAUTH_WELL_KNOWN_PATH}",
-                endpoint=handle_well_known,
+                endpoint=self.handle_well_known,
                 methods=["GET", "OPTIONS"],
             ),
             Route(
                 f"/{OPENID_WELL_KNOWN_PATH}",
-                endpoint=handle_well_known,
+                endpoint=self.handle_well_known,
                 methods=["GET", "OPTIONS"],
             ),
             Route(self.settings.sse_path, endpoint=handle_sse),
@@ -622,24 +615,17 @@ class MCPEngine:
         auth_backend = get_auth_backend(self.settings, self.scopes, self.scopes_mapping)
         transport = HttpServerTransport(self._mcp_server, auth_backend)
 
-        async def handle_well_known(_: Request) -> Response:
-            async with httpx.AsyncClient() as client:
-                issuer_url = str(self.settings.idp_config.issuer_url).rstrip("/") + "/"
-                well_known_url = urljoin(issuer_url, OPENID_WELL_KNOWN_PATH)
-                response = await client.get(well_known_url)
-                return JSONResponse(response.json())
-
         middleware: Sequence[Middleware] = []
 
         routes = [
             Route(
                 f"/{OAUTH_WELL_KNOWN_PATH}",
-                endpoint=handle_well_known,
+                endpoint=self.handle_well_known,
                 methods=["GET", "OPTIONS"],
             ),
             Route(
                 f"/{OPENID_WELL_KNOWN_PATH}",
-                endpoint=handle_well_known,
+                endpoint=self.handle_well_known,
                 methods=["GET", "OPTIONS"],
             ),
             Route(
@@ -685,6 +671,16 @@ class MCPEngine:
         except Exception as e:
             logger.error(f"Error getting prompt {name}: {e}")
             raise ValueError(str(e))
+
+    async def handle_well_known(self, _: Request) -> Response:
+        idp_config = self.settings.idp_config
+        if idp_config is None:
+            return Response(status_code=500, content="Invalid IdP configuration")
+        async with httpx.AsyncClient() as client:
+            issuer_url = str(idp_config.issuer_url).rstrip("/") + "/"
+            well_known_url = urljoin(issuer_url, OPENID_WELL_KNOWN_PATH)
+            response = await client.get(well_known_url)
+            return JSONResponse(response.json())
 
 
 def _convert_to_content(

--- a/src/mcpengine/server/settings.py
+++ b/src/mcpengine/server/settings.py
@@ -12,9 +12,10 @@ from contextlib import (
 )
 from typing import Any, Generic, Literal
 
-from pydantic import Field, HttpUrl
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from mcpengine.server.auth.providers.config import IdpConfig
 from mcpengine.server.lowlevel.server import LifespanResultT
 
 
@@ -65,9 +66,6 @@ class Settings(BaseSettings, Generic[LifespanResultT]):
     )
 
     # auth settings
-    authentication_enabled: bool = Field(
-        False, description="Enable authentication and authorization for the application"
-    )
-    issuer_url: HttpUrl | None = Field(
-        None, description="Url of the issuer, which will be used as the root url"
+    idp_config: IdpConfig | None = Field(
+        None, description="Configuration for an OAuth2 or OIDC provider"
     )

--- a/tests/server/auth/test_return_code.py
+++ b/tests/server/auth/test_return_code.py
@@ -19,7 +19,6 @@ def mock_bearer_token_backend():
             scopes_mapping=scopes_mapping,
         )
 
-        backend._get_jwks = AsyncMock(return_value=None)
         backend._decode_token = AsyncMock(return_value=token)
 
         return backend

--- a/tests/server/auth/test_return_code.py
+++ b/tests/server/auth/test_return_code.py
@@ -1,9 +1,9 @@
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from pydantic import HttpUrl
 
 from mcpengine.server.auth.backend import BearerTokenBackend
+from mcpengine.server.auth.providers.config import IdpConfig
 from mcpengine.server.sse import SseServerTransport
 from mcpengine.types import JSONRPCRequest
 
@@ -12,16 +12,15 @@ from mcpengine.types import JSONRPCRequest
 def mock_bearer_token_backend():
     def _create_mock(application_scopes, scopes_mapping, token):
         backend = BearerTokenBackend(
-            issuer_url=HttpUrl("http://some-issuer"),
+            idp_config=IdpConfig(
+                issuer_url="http://some-issuer",
+            ),
             scopes=application_scopes,
             scopes_mapping=scopes_mapping,
         )
 
         backend._get_jwks = AsyncMock(return_value=None)
-
-        validate_token_mock = MagicMock()
-        validate_token_mock.return_value = token
-        backend.validate_token = validate_token_mock
+        backend._decode_token = AsyncMock(return_value=token)
 
         return backend
 

--- a/uv.lock
+++ b/uv.lock
@@ -39,6 +39,18 @@ wheels = [
 ]
 
 [[package]]
+name = "async-lru"
+version = "2.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b2/4d/71ec4d3939dc755264f680f6c2b4906423a304c3d18e96853f0a595dfe97/async_lru-2.0.5.tar.gz", hash = "sha256:481d52ccdd27275f42c43a928b4a50c3bfb2d67af4e78b170e3e0bb39c66e5bb", size = 10380 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/49/d10027df9fce941cb8184e78a02857af36360d33e1721df81c5ed2179a1a/async_lru-2.0.5-py3-none-any.whl", hash = "sha256:ab95404d8d2605310d345932697371a5f40def0487c03d6d0ad9138de52c9943", size = 6069 },
+]
+
+[[package]]
 name = "attrs"
 version = "24.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -708,6 +720,7 @@ version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },
+    { name = "async-lru" },
     { name = "httpx" },
     { name = "httpx-sse" },
     { name = "pydantic" },
@@ -754,6 +767,7 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "anyio", specifier = ">=4.5" },
+    { name = "async-lru", specifier = "==2.0.5" },
     { name = "docker", marker = "extra == 'cli'", specifier = ">=7.1.0" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "httpx-sse", specifier = ">=0.4" },


### PR DESCRIPTION
Refactor the previous settings we had before to have an IdpConfig class.

Additionally, implement the GoogleIdpConfig class, to be used with Google OAuth providers.

Some small additional fixes:
- Implement caching on accessing various endpoints for the IdP.
- If no scopes are required in an application with auth enabled, we pass in a minimal scope with the 401. This is because having no scopes is not defined to be valid, and some IdPs (such as Google) return an error in this case.