### PR TITLE
Bump versions

### DIFF
--- a/examples/servers/lambda-weather/pyproject.toml
+++ b/examples/servers/lambda-weather/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 dependencies = [
     "httpx>=0.27.0",
-    "mcpengine[lambda]>=0.2.0",
+    "mcpengine[lambda]>=0.3.0",
 ]
 
 [tool.hatch.metadata]

--- a/examples/servers/smack/pyproject.toml
+++ b/examples/servers/smack/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
 ]
-dependencies = ["psycopg2-binary==2.9.9", "mcpengine[cli,lambda]>=0.2.0"]
+dependencies = ["psycopg2-binary==2.9.9", "mcpengine[cli,lambda]>=0.3.0"]
 
 [project.scripts]
 mcp-smack = "mcp_smack.server:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcpengine"
-version = "0.2.0"
+version = "0.3.0"
 description = "MCPEngine is a Model Context Protocol SDK built for Production"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -746,7 +746,7 @@ dev = [
 
 [[package]]
 name = "mcpengine"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
Bump version of mcpengine to 0.3, and update the examples that require this new version.