### PR TITLE
Exit on STDIN close

### DIFF
--- a/mcpengine-proxy/http_test.go
+++ b/mcpengine-proxy/http_test.go
@@ -68,7 +68,7 @@ func TestHTTPPostSender_WritesMessages(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	go sender.Run(ctx)
+	go sender.Run(ctx, cancel)
 
 	// Allow some time for processing.
 	time.Sleep(200 * time.Millisecond)
@@ -104,7 +104,7 @@ func TestHTTPPostSender_Cancellation(t *testing.T) {
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- sender.Run(ctx)
+		errCh <- sender.Run(ctx, cancel)
 	}()
 
 	// Cancel immediately
@@ -134,8 +134,8 @@ func TestHTTPPostSender_InvalidURL(t *testing.T) {
 
 	sender := NewHTTPPostSender(client, "http://example.com", endpointChan, inputChan, outputChan, auth, logger)
 
-	ctx := context.Background()
-	err := sender.Run(ctx)
+	ctx, cancel := context.WithCancel(context.Background())
+	err := sender.Run(ctx, cancel)
 
 	// Should return an error for invalid URL
 	if err == nil {
@@ -172,7 +172,7 @@ func TestHTTPPostSender_HTTPError(t *testing.T) {
 	defer cancel()
 
 	// This should not crash despite the HTTP error
-	go sender.Run(ctx)
+	go sender.Run(ctx, cancel)
 
 	// Allow time for processing
 	time.Sleep(200 * time.Millisecond)
@@ -206,7 +206,7 @@ func TestHTTPPostSender_UnexpectedStatusCode(t *testing.T) {
 	defer cancel()
 
 	// This should not crash despite the 500 error
-	go sender.Run(ctx)
+	go sender.Run(ctx, cancel)
 
 	// Allow time for processing
 	time.Sleep(200 * time.Millisecond)

--- a/mcpengine-proxy/sse_test.go
+++ b/mcpengine-proxy/sse_test.go
@@ -46,7 +46,7 @@ func TestSSEWorker_PassesEndpointAndMessages(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	go worker.Run(ctx)
+	go worker.Run(ctx, cancel)
 	<-fakeClient.IsSubscribed // Wait for subscription
 
 	// Simulate sending SSE events
@@ -136,7 +136,7 @@ func TestSSEWorker_EndpointDetection(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 			defer cancel()
 
-			go worker.Run(ctx)
+			go worker.Run(ctx, cancel)
 			<-fakeClient.IsSubscribed
 
 			// Send the test message
@@ -201,7 +201,7 @@ func TestSSEWorker_SkipsSubsequentEndpoints(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	go worker.Run(ctx)
+	go worker.Run(ctx, cancel)
 	<-fakeClient.IsSubscribed
 
 	// Send two endpoint messages - only the first should be forwarded
@@ -272,7 +272,7 @@ func TestSSEWorker_Cancellation(t *testing.T) {
 	// Run the worker in a goroutine and capture the result
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- worker.Run(ctx)
+		errCh <- worker.Run(ctx, cancel)
 	}()
 
 	// Wait for subscription
@@ -304,12 +304,12 @@ func TestSSEWorker_EventChannelClosure(t *testing.T) {
 
 	worker := NewSSEWorker(fakeClient, endpointChan, outputChan, logger)
 
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
 
 	// Run the worker in a goroutine and capture the result
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- worker.Run(ctx)
+		errCh <- worker.Run(ctx, cancel)
 	}()
 
 	// Wait for subscription
@@ -348,7 +348,7 @@ func TestSSEWorker_SubscribeError(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 
-	err := worker.Run(ctx)
+	err := worker.Run(ctx, cancel)
 
 	// Should return context cancellation error, not subscription error
 	if err != context.DeadlineExceeded {

--- a/mcpengine-proxy/testutil/reader.go
+++ b/mcpengine-proxy/testutil/reader.go
@@ -1,0 +1,61 @@
+package testutil
+
+import (
+	"io"
+	"os"
+	"testing"
+)
+
+// BlockReader reads from the underlying Reader until EOF,
+// then blocks forever on subsequent reads
+type BlockReader struct {
+	r          io.Reader
+	reachedEOF bool
+	blockChan  chan struct{}
+}
+
+// NewBlockReader creates a new reader that will block after EOF
+func NewBlockReader(r io.Reader) *BlockReader {
+	return &BlockReader{
+		r:          r,
+		reachedEOF: false,
+		blockChan:  make(chan struct{}), // Unbuffered channel that's never closed
+	}
+}
+
+func (r *BlockReader) Read(p []byte) (n int, err error) {
+	if r.reachedEOF {
+		// Block forever by trying to receive from a channel that will never send
+		<-r.blockChan
+		return 0, nil // This line is never reached
+	}
+
+	n, err = r.r.Read(p)
+	if err == io.EOF {
+		r.reachedEOF = true
+		return n, nil // Return the data but suppress the EOF
+	}
+	return n, err
+}
+
+func CreateTempBlockReader(t *testing.T, content string) io.Reader {
+	t.Helper()
+	tmpFile, err := os.CreateTemp("", "mcpengine_input_*")
+	if err != nil {
+		t.Fatalf("Failed to create temporary file: %v", err)
+	}
+	t.Cleanup(func() {
+		err := os.Remove(tmpFile.Name())
+		if err != nil {
+			t.Errorf("Failed to remove temporary file: %v", err)
+		}
+	})
+
+	if _, err := tmpFile.WriteString(content); err != nil {
+		t.Fatalf("Failed to write to temporary file: %v", err)
+	}
+	if _, err := tmpFile.Seek(0, 0); err != nil {
+		t.Fatalf("Failed to reset temporary file: %v", err)
+	}
+	return NewBlockReader(tmpFile)
+}


### PR DESCRIPTION
When STDIN is closed, add behavior to exit the program.

This ensures that when the client is no longer connected, we properly close and release our resources. This helps, for example, in the case where Claude runs the client command multiple times, or when for some reason after Claude exits the process still runs.