### PR TITLE
fixing 1 typo in examples/README

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,5 +1,5 @@
 # Python SDK Examples
 
-This folders aims to provide simple examples of using the Python SDK. Please refer to the
+This folder aims to provide simple examples of using the Python SDK. Please refer to the
 [servers repository](https://github.com/modelcontextprotocol/servers)
 for real-world servers.


### PR DESCRIPTION
Hi,
as per title.
See commit diff for details
Didier