### PR TITLE
Add configurable ports

### DIFF
--- a/mcpengine-proxy/auth.go
+++ b/mcpengine-proxy/auth.go
@@ -9,8 +9,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -108,7 +106,7 @@ type AuthManager struct {
 // If a nil or partially populated config is provided, missing fields are replaced with defaults.
 func NewAuthManager(cfg *AuthConfig, logger *zap.SugaredLogger) *AuthManager {
 	cfg = resolveConfig(cfg)
-	redirectURL := getRedirectURL(cfg.ListenPort, cfg.CallbackPath)
+	redirectURL := fmt.Sprintf("http://localhost:%d%s", cfg.ListenPort, cfg.CallbackPath)
 	return &AuthManager{
 		clientID:         cfg.ClientID,
 		clientSecret:     cfg.ClientSecret,
@@ -401,16 +399,4 @@ func generateState() string {
 		return fmt.Sprintf("%d", time.Now().UnixNano())
 	}
 	return base64.StdEncoding.EncodeToString(b)
-}
-
-func getRedirectURL(port int, callbackPath string) string {
-	// This is useful in the case of Docker port mapping, where the
-	// host port and the container port are not the same.
-	hostPortStr := os.Getenv("HOST_PORT")
-	if hostPort, err := strconv.Atoi(hostPortStr); err == nil {
-		port = hostPort
-	}
-
-	redirectURL := fmt.Sprintf("http://localhost:%d%s", port, callbackPath)
-	return redirectURL
 }

--- a/mcpengine-proxy/cmd/main.go
+++ b/mcpengine-proxy/cmd/main.go
@@ -19,6 +19,7 @@ func main() {
 	ssePath := flag.String("sse_path", "/sse", "The path to append to hostname for an /sse connection")
 	mcpPath := flag.String("mcp_path", "/mcp", "The path to append to hostname for non-SSE POST")
 	debug := flag.Bool("debug", false, "Enable debug logging")
+	authListenPort := flag.Int("auth_port", 8181, "The port on which the auth server listens")
 	flag.Parse()
 
 	if *mode != "sse" && *mode != "http" {
@@ -55,6 +56,7 @@ func main() {
 		AuthConfig: &mcpengine.AuthConfig{
 			ClientID:     *clientId,
 			ClientSecret: *clientSecret,
+			ListenPort:   *authListenPort,
 		},
 		Logger: logger,
 	})

--- a/src/mcpengine/cli/claude.py
+++ b/src/mcpengine/cli/claude.py
@@ -112,7 +112,8 @@ def install_proxy(
         "-i",
         "--rm",
         "-p",
-        f"{port}:8181",
+        f"-auth_port={port}",
+        f"{port}:{port}",
         PROXY_IMAGE_NAME,
         f"-host={host_endpoint}",
     ]

--- a/src/mcpengine/cli/claude.py
+++ b/src/mcpengine/cli/claude.py
@@ -96,6 +96,7 @@ def install_proxy(
     name: str,
     host_endpoint: str,
     *,
+    port: int = 8181,
     mode: str | None = None,
     client_id: str | None = None,
     client_secret: str | None = None,
@@ -111,7 +112,7 @@ def install_proxy(
         "-i",
         "--rm",
         "-p",
-        "8181:8181",
+        f"{port}:8181",
         PROXY_IMAGE_NAME,
         f"-host={host_endpoint}",
     ]

--- a/src/mcpengine/cli/cli.py
+++ b/src/mcpengine/cli/cli.py
@@ -494,6 +494,13 @@ def proxy(
         TransportMode,
         typer.Option("--mode", "-m", help="The transport mode of the MCP server."),
     ] = TransportMode.sse,
+    port: Annotated[
+        int,
+        typer.Option(
+            "--port",
+            "-p",
+        ),
+    ] = 8181,
     client_id: Annotated[
         str | None,
         typer.Option(
@@ -551,6 +558,7 @@ def proxy(
         if claude.install_proxy(
             name=name,
             host_endpoint=host_endpoint,
+            port=port,
             client_id=client_id,
             client_secret=client_secret,
             mode=mode.value,


### PR DESCRIPTION
Add configurable ports to both:
- mcpengine cli, so that when you run the proxy command (and thus configure it to run it via Docker), you can configure a port on the host to listen to.
- mcpengine proxy, in cases where you want to run the proxy on its own.