### PR TITLE
Implement 'Add' command for installing server file configs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
 [project.optional-dependencies]
 lambda = ["mangum==0.19.0"]
 rich = ["rich>=13.9.4"]
-cli = ["typer>=0.12.4", "python-dotenv>=1.0.0", "docker>=7.1.0"]
+cli = ["typer>=0.12.4", "python-dotenv>=1.0.0", "docker>=7.1.0", "pyyaml>=6.0.2", "questionary>=2.1.0"]
 ws = ["websockets>=15.0.1"]
 
 [project.scripts]

--- a/src/mcpengine/cli/claude.py
+++ b/src/mcpengine/cli/claude.py
@@ -32,7 +32,7 @@ def get_claude_config_path() -> Path | None:
     return None
 
 
-def _update_server_config(
+def update_server_config(
     name: str,
     entry: dict[str, Any],
 ) -> bool:
@@ -133,7 +133,7 @@ def install_proxy(
         "args": args,
     }
 
-    return _update_server_config(name, config)
+    return update_server_config(name, config)
 
 
 def update_claude_config(
@@ -190,4 +190,4 @@ def update_claude_config(
     if env_vars:
         server_config["env"] = env_vars
 
-    return _update_server_config(server_name, server_config)
+    return update_server_config(server_name, server_config)

--- a/src/mcpengine/cli/cli.py
+++ b/src/mcpengine/cli/cli.py
@@ -490,8 +490,7 @@ def add(
         bool, typer.Option("--claude", help="Add the installation to Claude config.")
     ] = False,
 ):
-    """Adds an MCP server via a config file.
-    """
+    """Adds an MCP server via a config file."""
     config = get_config(path)
     command = prompt_command(config)
 

--- a/src/mcpengine/cli/server.py
+++ b/src/mcpengine/cli/server.py
@@ -62,6 +62,8 @@ def _get_run_command(config: ServerConfig, inputs: dict[str, str]) -> str:
 
 def get_config(config_path: Path) -> ServerConfig:
     config = _load_config_file(config_path)
+    if config.version != "1.0":
+        raise ValueError(f"Unsupported version: {config.version}")
     return config
 
 

--- a/src/mcpengine/cli/server.py
+++ b/src/mcpengine/cli/server.py
@@ -1,0 +1,71 @@
+from pathlib import Path
+from string import Template
+from typing import Any
+
+import yaml
+from pydantic import BaseModel
+from questionary import prompt
+
+
+class Requirement(BaseModel):
+    name: str
+    version: str
+    install_hint: str
+
+
+class Input(BaseModel):
+    name: str
+    type: str
+    message: str
+    default: Any = None
+    choices: list[str] | None = None
+
+
+class ServerConfig(BaseModel):
+    name: str
+    version: str
+    description: str
+    requires: list[Requirement]
+    inputs: list[Input]
+    command: str
+
+
+def _load_config_file(config_path: Path) -> ServerConfig:
+    try:
+        with open(config_path) as file:
+            data = yaml.safe_load(file)
+            return ServerConfig(**data)
+    except Exception as e:
+        raise Exception(f"Failed to load configuration from {config_path}") from e
+
+
+def _prompt_inputs(inputs: list[Input]) -> dict[str, str]:
+    # Removing unused parameters.
+    questions: list[dict[str, Any]] = []
+    for model in inputs:
+        result: dict[str, Any] = {}
+        for field_name in model.model_fields.keys():
+            field_value = getattr(model, field_name)
+            if field_value is None:
+                continue
+            result[str(field_name)] = field_value
+        questions.append(result)
+
+    return prompt(questions)
+
+
+def _get_run_command(config: ServerConfig, inputs: dict[str, str]) -> str:
+    template_string = Template(config.command)
+    value_string = template_string.safe_substitute(**inputs)
+    return value_string
+
+
+def get_config(config_path: Path) -> ServerConfig:
+    config = _load_config_file(config_path)
+    return config
+
+
+def prompt_command(config: ServerConfig) -> str:
+    inputs = _prompt_inputs(config.inputs)
+    run_command = _get_run_command(config, inputs)
+    return run_command

--- a/src/mcpengine/cli/server.py
+++ b/src/mcpengine/cli/server.py
@@ -4,7 +4,7 @@ from string import Template
 from typing import Any
 
 import yaml
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from questionary import prompt
 
 
@@ -26,8 +26,8 @@ class ServerConfig(BaseModel):
     name: str
     version: str
     description: str
-    requires: list[Requirement]
-    inputs: list[Input]
+    requires: list[Requirement] = Field(default_factory=list)
+    inputs: list[Input] = Field(default_factory=list)
     command: str
 
 
@@ -63,7 +63,7 @@ def _get_run_command(config: ServerConfig, inputs: dict[str, str]) -> str:
 
 def get_config(config_path: Path) -> ServerConfig:
     config = _load_config_file(config_path)
-    if config.version != "1.0":
+    if config.version != "v1":
         raise ValueError(f"Unsupported version: {config.version}")
     return config
 

--- a/src/mcpengine/cli/server.py
+++ b/src/mcpengine/cli/server.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from shutil import which
 from string import Template
 from typing import Any
 
@@ -68,6 +69,10 @@ def get_config(config_path: Path) -> ServerConfig:
 
 
 def prompt_command(config: ServerConfig) -> str:
+    for requirement in config.requires:
+        if which(requirement.name) is None:
+            raise ValueError(f"Requirement {requirement.name} is not installed")
+
     inputs = _prompt_inputs(config.inputs)
     run_command = _get_run_command(config, inputs)
     return run_command

--- a/src/mcpengine/cli/server.py
+++ b/src/mcpengine/cli/server.py
@@ -10,7 +10,6 @@ from questionary import prompt
 
 class Requirement(BaseModel):
     name: str
-    version: str
     install_hint: str
 
 
@@ -71,7 +70,10 @@ def get_config(config_path: Path) -> ServerConfig:
 def prompt_command(config: ServerConfig) -> str:
     for requirement in config.requires:
         if which(requirement.name) is None:
-            raise ValueError(f"Requirement {requirement.name} is not installed")
+            raise ValueError(
+                f"Requirement {requirement.name} is not installed: "
+                f"{requirement.install_hint}"
+            )
 
     inputs = _prompt_inputs(config.inputs)
     run_command = _get_run_command(config, inputs)

--- a/tests/cli/configs/invalid/missing-section.yaml
+++ b/tests/cli/configs/invalid/missing-section.yaml
@@ -1,3 +1,3 @@
-name: empty
+name: missing-section
 version: v1
-description: Is an empty file config
+description: Missing command section

--- a/tests/cli/configs/invalid/missing-section.yaml
+++ b/tests/cli/configs/invalid/missing-section.yaml
@@ -1,0 +1,3 @@
+name: empty
+version: v1
+description: Is an empty file config

--- a/tests/cli/configs/invalid/wrong-version.yaml
+++ b/tests/cli/configs/invalid/wrong-version.yaml
@@ -1,4 +1,4 @@
-name: empty
+name: wrong-version
 version: v0
-description: Is an empty file config
+description: There is no version v0
 command: ls

--- a/tests/cli/configs/invalid/wrong-version.yaml
+++ b/tests/cli/configs/invalid/wrong-version.yaml
@@ -1,0 +1,4 @@
+name: empty
+version: v0
+description: Is an empty file config
+command: ls

--- a/tests/cli/configs/valid/empty.yaml
+++ b/tests/cli/configs/valid/empty.yaml
@@ -1,0 +1,4 @@
+name: empty
+version: v1
+description: Is an empty file config
+command: ls

--- a/tests/cli/configs/valid/full.yaml
+++ b/tests/cli/configs/valid/full.yaml
@@ -3,10 +3,8 @@ version: v1
 description: This is a file that includes all optional sections
 requires:
   - name: docker
-    version: "1.0"
     install_hint: docker install hint
   - name: npx
-    version: "1.0"
     install_hint: npx install hint
 inputs:
   - name: input1
@@ -21,4 +19,4 @@ inputs:
       - input2-default
       - another input
       - something
-command: ls
+command: ls ${input1} ${input2}

--- a/tests/cli/configs/valid/full.yaml
+++ b/tests/cli/configs/valid/full.yaml
@@ -1,0 +1,24 @@
+name: full
+version: v1
+description: This is a file that includes all optional sections
+requires:
+  - name: docker
+    version: "1.0"
+    install_hint: docker install hint
+  - name: npx
+    version: "1.0"
+    install_hint: npx install hint
+inputs:
+  - name: input1
+    type: text
+    message: Please input input1
+    default: input1-default
+  - name: input2
+    type: choice
+    message: Please input input2
+    default: input2-default
+    choices:
+      - input2-default
+      - another input
+      - something
+command: ls

--- a/tests/cli/test_server_config.py
+++ b/tests/cli/test_server_config.py
@@ -11,9 +11,10 @@ from mcpengine.cli.server import (
     prompt_command,
 )
 
-CONFIG_DIR_PATH = "./configs"
-VALID_CONFIG_DIR_PATH = "./configs/valid"
-INVALID_CONFIG_DIR_PATH = "./configs/invalid"
+CURRENT_PATH = path.dirname(__file__)
+CONFIG_DIR_PATH = path.join(CURRENT_PATH, "./configs")
+VALID_CONFIG_DIR_PATH = path.join(CONFIG_DIR_PATH, "valid")
+INVALID_CONFIG_DIR_PATH = path.join(CONFIG_DIR_PATH, "invalid")
 
 def test_empty_config():
     """Tests a minimal server config file to be parsed properly."""

--- a/tests/cli/test_server_config.py
+++ b/tests/cli/test_server_config.py
@@ -1,0 +1,98 @@
+from os import listdir, path
+from unittest.mock import patch
+
+import pytest
+
+from mcpengine.cli.server import (
+    Input,
+    Requirement,
+    ServerConfig,
+    get_config,
+    prompt_command,
+)
+
+CONFIG_DIR_PATH = "./configs"
+VALID_CONFIG_DIR_PATH = "./configs/valid"
+INVALID_CONFIG_DIR_PATH = "./configs/invalid"
+
+def test_empty_config():
+    """Tests a minimal server config file to be parsed properly."""
+    config = get_config(path.join(VALID_CONFIG_DIR_PATH, "empty.yaml"))
+
+    assert config.name == "empty"
+    assert config.version == "v1"
+    assert config.description is not None
+    assert config.command == "ls"
+    assert config.requires == []
+    assert config.inputs == []
+
+def test_full_config():
+    """Tests a server config with all optional sections to be parsed properly."""
+    config = get_config(path.join(VALID_CONFIG_DIR_PATH, "full.yaml"))
+
+    assert config.name == "full"
+    assert config.version == "v1"
+    assert config.description is not None
+    assert config.command == "ls"
+    assert config.requires == [
+        Requirement(
+            name="docker",
+            version="1.0",
+            install_hint="docker install hint",
+        ),
+        Requirement(
+            name= "npx",
+            version= "1.0",
+            install_hint= "npx install hint",
+        )
+    ]
+    assert config.inputs == [
+        Input(
+            name= "input1",
+            type= "text",
+            message= "Please input input1",
+            default= "input1-default",
+        ),
+        Input(
+            name= "input2",
+            type= "choice",
+            message= "Please input input2",
+            default= "input2-default",
+            choices= [
+                "input2-default",
+                "another input",
+                "something",
+            ]
+        )
+    ]
+
+def test_invalid_configs():
+    """Tests all the invalid configs to ensure that they throw an Exception."""
+    for invalid_config in listdir(INVALID_CONFIG_DIR_PATH):
+        with pytest.raises(Exception):
+            get_config(path.join(INVALID_CONFIG_DIR_PATH, invalid_config))
+
+def test_command_template():
+    """Tests that the templating in the run_command works after obtaining inputs."""
+    config = ServerConfig(
+        name="test",
+        version="v1",
+        description="test",
+        inputs=[
+            Input(name="input1", type= "text", message= "input1"),
+            Input(name="input2", type= "text", message= "input2"),
+        ],
+        command="cat ${input1} ${input2}"
+    )
+    prompt_return_value=  {
+        "input1": "input1-value",
+        "input2": "input2-value",
+    }
+
+    prompt_input_path = "mcpengine.cli.server._prompt_inputs"
+    with patch(prompt_input_path) as mock_prompt_inputs:
+        mock_prompt_inputs.return_value = prompt_return_value
+
+        command = prompt_command(config)
+        assert command == "cat input1-value input2-value"
+

--- a/tests/cli/test_server_config.py
+++ b/tests/cli/test_server_config.py
@@ -37,16 +37,16 @@ def test_full_config():
     assert config.name == "full"
     assert config.version == "v1"
     assert config.description is not None
-    assert config.command == "ls"
+    # This happens before input templating, so the command still has
+    # templates in it.
+    assert config.command == "ls ${input1} ${input2}"
     assert config.requires == [
         Requirement(
             name="docker",
-            version="1.0",
             install_hint="docker install hint",
         ),
         Requirement(
             name="npx",
-            version="1.0",
             install_hint="npx install hint",
         ),
     ]

--- a/tests/cli/test_server_config.py
+++ b/tests/cli/test_server_config.py
@@ -17,6 +17,7 @@ CONFIG_DIR_PATH = path.join(CURRENT_PATH, "./configs")
 VALID_CONFIG_DIR_PATH = path.join(CONFIG_DIR_PATH, "valid")
 INVALID_CONFIG_DIR_PATH = path.join(CONFIG_DIR_PATH, "invalid")
 
+
 def test_empty_config():
     """Tests a minimal server config file to be parsed properly."""
     config = get_config(Path(path.join(VALID_CONFIG_DIR_PATH, "empty.yaml")))
@@ -27,6 +28,7 @@ def test_empty_config():
     assert config.command == "ls"
     assert config.requires == []
     assert config.inputs == []
+
 
 def test_full_config():
     """Tests a server config with all optional sections to be parsed properly."""
@@ -43,36 +45,38 @@ def test_full_config():
             install_hint="docker install hint",
         ),
         Requirement(
-            name= "npx",
-            version= "1.0",
-            install_hint= "npx install hint",
-        )
+            name="npx",
+            version="1.0",
+            install_hint="npx install hint",
+        ),
     ]
     assert config.inputs == [
         Input(
-            name= "input1",
-            type= "text",
-            message= "Please input input1",
-            default= "input1-default",
+            name="input1",
+            type="text",
+            message="Please input input1",
+            default="input1-default",
         ),
         Input(
-            name= "input2",
-            type= "choice",
-            message= "Please input input2",
-            default= "input2-default",
-            choices= [
+            name="input2",
+            type="choice",
+            message="Please input input2",
+            default="input2-default",
+            choices=[
                 "input2-default",
                 "another input",
                 "something",
-            ]
-        )
+            ],
+        ),
     ]
+
 
 def test_invalid_configs():
     """Tests all the invalid configs to ensure that they throw an Exception."""
     for invalid_config in listdir(INVALID_CONFIG_DIR_PATH):
         with pytest.raises(Exception):
             get_config(Path(path.join(INVALID_CONFIG_DIR_PATH, invalid_config)))
+
 
 def test_command_template():
     """Tests that the templating in the run_command works after obtaining inputs."""
@@ -81,12 +85,12 @@ def test_command_template():
         version="v1",
         description="test",
         inputs=[
-            Input(name="input1", type= "text", message= "input1"),
-            Input(name="input2", type= "text", message= "input2"),
+            Input(name="input1", type="text", message="input1"),
+            Input(name="input2", type="text", message="input2"),
         ],
-        command="cat ${input1} ${input2}"
+        command="cat ${input1} ${input2}",
     )
-    prompt_return_value=  {
+    prompt_return_value = {
         "input1": "input1-value",
         "input2": "input2-value",
     }
@@ -97,4 +101,3 @@ def test_command_template():
 
         command = prompt_command(config)
         assert command == "cat input1-value input2-value"
-

--- a/tests/cli/test_server_config.py
+++ b/tests/cli/test_server_config.py
@@ -1,4 +1,5 @@
 from os import listdir, path
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -18,7 +19,7 @@ INVALID_CONFIG_DIR_PATH = path.join(CONFIG_DIR_PATH, "invalid")
 
 def test_empty_config():
     """Tests a minimal server config file to be parsed properly."""
-    config = get_config(path.join(VALID_CONFIG_DIR_PATH, "empty.yaml"))
+    config = get_config(Path(path.join(VALID_CONFIG_DIR_PATH, "empty.yaml")))
 
     assert config.name == "empty"
     assert config.version == "v1"
@@ -29,7 +30,7 @@ def test_empty_config():
 
 def test_full_config():
     """Tests a server config with all optional sections to be parsed properly."""
-    config = get_config(path.join(VALID_CONFIG_DIR_PATH, "full.yaml"))
+    config = get_config(Path(path.join(VALID_CONFIG_DIR_PATH, "full.yaml")))
 
     assert config.name == "full"
     assert config.version == "v1"
@@ -71,7 +72,7 @@ def test_invalid_configs():
     """Tests all the invalid configs to ensure that they throw an Exception."""
     for invalid_config in listdir(INVALID_CONFIG_DIR_PATH):
         with pytest.raises(Exception):
-            get_config(path.join(INVALID_CONFIG_DIR_PATH, invalid_config))
+            get_config(Path(path.join(INVALID_CONFIG_DIR_PATH, invalid_config)))
 
 def test_command_template():
     """Tests that the templating in the run_command works after obtaining inputs."""

--- a/uv.lock
+++ b/uv.lock
@@ -765,6 +765,8 @@ dependencies = [
 cli = [
     { name = "docker" },
     { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "questionary" },
     { name = "typer" },
 ]
 lambda = [
@@ -806,6 +808,8 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.5.2" },
     { name = "pyjwt", extras = ["crypto"], specifier = "==2.10.1" },
     { name = "python-dotenv", marker = "extra == 'cli'", specifier = ">=1.0.0" },
+    { name = "pyyaml", marker = "extra == 'cli'", specifier = ">=6.0.2" },
+    { name = "questionary", marker = "extra == 'cli'", specifier = ">=2.1.0" },
     { name = "rich", marker = "extra == 'rich'", specifier = ">=13.9.4" },
     { name = "sse-starlette", specifier = ">=1.6.1" },
     { name = "starlette", specifier = ">=0.27" },
@@ -1111,6 +1115,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556 },
+]
+
+[[package]]
+name = "prompt-toolkit"
+version = "2.0.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0c/37/7ad3bf3c6dbe96facf9927ddf066fdafa0f86766237cff32c3c7355d3b7c/prompt_toolkit-2.0.10.tar.gz", hash = "sha256:f15af68f66e664eaa559d4ac8a928111eebd5feda0c11738b5998045224829db", size = 347981 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/61/2dfea88583d5454e3a64f9308a686071d58d59a55db638268a6413e1eb6d/prompt_toolkit-2.0.10-py3-none-any.whl", hash = "sha256:46642344ce457641f28fc9d1c9ca939b63dadf8df128b86f1b9860e59c73a5e4", size = 340048 },
 ]
 
 [[package]]
@@ -1470,6 +1487,18 @@ wheels = [
 ]
 
 [[package]]
+name = "questionary"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "prompt-toolkit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/b8/d16eb579277f3de9e56e5ad25280fab52fc5774117fb70362e8c2e016559/questionary-2.1.0.tar.gz", hash = "sha256:6302cdd645b19667d8f6e6634774e9538bfcd1aad9be287e743d96cacaf95587", size = 26775 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/3f/11dd4cd4f39e05128bfd20138faea57bec56f9ffba6185d276e3107ba5b2/questionary-2.1.0-py3-none-any.whl", hash = "sha256:44174d237b68bc828e4878c763a9ad6790ee61990e0ae72927694ead57bab8ec", size = 36747 },
+]
+
+[[package]]
 name = "regex"
 version = "2024.11.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1800,6 +1829,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065 },
     { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070 },
     { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067 },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.2.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/63/53559446a878410fc5a5974feb13d31d78d752eb18aeba59c7fef1af7598/wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5", size = 101301 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/84/fd2ba7aafacbad3c4201d395674fc6348826569da3c0937e75505ead3528/wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859", size = 34166 },
 ]
 
 [[package]]


### PR DESCRIPTION
Implements a new `mcpengine add` command, that takes in a file that contains server config, and adds it to an installation target.