### PR TITLE
Implement protected resource metadata in mcp server

### DIFF
--- a/src/mcpengine/server/auth/backend.py
+++ b/src/mcpengine/server/auth/backend.py
@@ -18,7 +18,10 @@ from starlette.responses import Response
 import mcpengine
 from mcpengine.server.auth.context import UserContext
 from mcpengine.server.auth.errors import AuthenticationError, AuthorizationError
-from mcpengine.server.auth.providers.config import IdpConfig
+from mcpengine.server.auth.providers.config import (
+    OAUTH_PROTECTED_RESOURCE_METADATA_PATH,
+    IdpConfig,
+)
 from mcpengine.server.mcpengine.utilities.logging import get_logger
 from mcpengine.types import JSONRPCMessage
 
@@ -96,7 +99,17 @@ class BearerTokenBackend(AuthenticationBackend):
         # (and most OAuth IdPs should also support it).
         if len(scopes) == 0:
             scopes = ["openid"]
-        bearer = f'Bearer scope="{" ".join(scopes)}"'
+
+        resource_metadata_url = (
+            f"{self.idp_config.hostname}/"
+            f"{OAUTH_PROTECTED_RESOURCE_METADATA_PATH}"
+        )
+
+        bearer = (
+            'Bearer '
+            f'resource_metadata="{resource_metadata_url}", '
+            f'scope="{" ".join(scopes)}"'
+        )
 
         if isinstance(err, AuthorizationError):
             status_code = 403

--- a/src/mcpengine/server/auth/providers/config.py
+++ b/src/mcpengine/server/auth/providers/config.py
@@ -10,16 +10,25 @@ from async_lru import alru_cache
 
 OPENID_WELL_KNOWN_PATH: str = ".well-known/openid-configuration"
 OAUTH_WELL_KNOWN_PATH: str = ".well-known/oauth-authorization-server"
+OAUTH_PROTECTED_RESOURCE_METADATA_PATH: str = ".well-known/oauth-protected-resource"
 
 METADATA_CACHE_TTL = 300  # in seconds
 
 
 class IdpConfig:
+    hostname: str
     issuer_url: str
     token_validation_endpoint: str | None
 
-    def __init__(self, issuer_url: str, token_validation_endpoint: str | None = None):
+    def __init__(
+            self,
+            *,
+            hostname: str,
+            issuer_url: str,
+            token_validation_endpoint: str | None = None,
+    ):
         super().__init__()
+        self.hostname = hostname
         self.issuer_url = issuer_url
         self.token_validation_endpoint = token_validation_endpoint
 

--- a/src/mcpengine/server/auth/providers/google.py
+++ b/src/mcpengine/server/auth/providers/google.py
@@ -13,8 +13,8 @@ TOKEN_VALIDATION_ENDPOINT = "https://oauth2.googleapis.com/tokeninfo"
 
 
 class GoogleIdpConfig(IdpConfig):
-    def __init__(self):
-        super().__init__(ISSUER_URL)
+    def __init__(self, *, hostname: str):
+        super().__init__(hostname=hostname, issuer_url=ISSUER_URL)
 
     async def validate_token(self, token: str) -> dict[str, Any]:
         async with httpx.AsyncClient() as client:

--- a/tests/server/auth/test_return_code.py
+++ b/tests/server/auth/test_return_code.py
@@ -13,6 +13,7 @@ def mock_bearer_token_backend():
     def _create_mock(application_scopes, scopes_mapping, token):
         backend = BearerTokenBackend(
             idp_config=IdpConfig(
+                hostname="http://localhost:8000",
                 issuer_url="http://some-issuer",
             ),
             scopes=application_scopes,


### PR DESCRIPTION
Implements [Protected Resource Metadata](https://datatracker.ietf.org/doc/rfc9728/) in mcp-engine.

This RFC essentially requires a new (well known) endpoint located at ".well-known/oauth-protected-resource", which gives metadata about auth related items (such as the authorization servers the client should reach out to).

This PR implements support by:
- Exposing this new endpoint
- Returning the address of this endpoint 401 and 403 responses, within the `WWW-Authenticate` header.