### PR TITLE
Fix docker command for proxy

### DIFF
--- a/src/mcpengine/cli/claude.py
+++ b/src/mcpengine/cli/claude.py
@@ -112,9 +112,9 @@ def install_proxy(
         "-i",
         "--rm",
         "-p",
-        f"-auth_port={port}",
         f"{port}:{port}",
         PROXY_IMAGE_NAME,
+        f"-auth_port={port}",
         f"-host={host_endpoint}",
     ]
 


### PR DESCRIPTION
The docker command has some arguments that are mixed, fixed the ordering of them.