### PR TITLE
Add configuration for whether list calls require auth

### DIFF
--- a/src/mcpengine/server/auth/backend.py
+++ b/src/mcpengine/server/auth/backend.py
@@ -69,11 +69,10 @@ class NoAuthBackend(AuthenticationBackend):
 
 
 class BearerTokenBackend(AuthenticationBackend):
-    # TODO: Better way of doing this
-    METHODS_CHECK: set[str] = {
-        "tools/call",
-        "resources/read",
-        "prompts/get",
+    LIST_CALLS: set[str] = {
+        "tools/list",
+        "resources/list",
+        "prompts/list",
     }
 
     idp_config: IdpConfig
@@ -130,7 +129,13 @@ class BearerTokenBackend(AuthenticationBackend):
             return None
         req_message = message.root
 
-        if req_message.method not in self.METHODS_CHECK:
+        if req_message.method == "initialize":
+            return None
+
+        if (
+            self.idp_config.allow_unauthenticated_list
+            and req_message.method in self.LIST_CALLS
+        ):
             return None
 
         try:

--- a/src/mcpengine/server/auth/providers/config.py
+++ b/src/mcpengine/server/auth/providers/config.py
@@ -19,18 +19,21 @@ class IdpConfig:
     hostname: str
     issuer_url: str
     token_validation_endpoint: str | None
+    allow_unauthenticated_list: bool = False
 
     def __init__(
-            self,
-            *,
-            hostname: str,
-            issuer_url: str,
-            token_validation_endpoint: str | None = None,
+        self,
+        *,
+        hostname: str,
+        issuer_url: str,
+        token_validation_endpoint: str | None = None,
+        allow_unauthenticated_list: bool = False,
     ):
         super().__init__()
         self.hostname = hostname
         self.issuer_url = issuer_url
         self.token_validation_endpoint = token_validation_endpoint
+        self.allow_unauthenticated_list = allow_unauthenticated_list
 
     @alru_cache(ttl=METADATA_CACHE_TTL)
     async def get_metadata(self) -> Any:


### PR DESCRIPTION
Adds a new configuration parameter to the auth configuration `allow_unauthenticated_list` on whether resources list calls require auth or not (defaults to requiring auth).